### PR TITLE
Fix a typo in compiler option name

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,4 +43,4 @@ unmanagedJars in Compile += dokkaJavaApiJar
 
 fork.in(run) := true
 
-scalacOptions in Compile += "-language:implicitConversion"
+scalacOptions in Compile += "-language:implicitConversions"


### PR DESCRIPTION
Fix a typo in compiler option name.