### PR TITLE
Update dottyc to 0.26.0-RC1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val dottyVersion = "0.25.0-RC2"
+val dottyVersion = "0.26.0-RC1"
 
 libraryDependencies += "org.jetbrains.dokka" % "dokka-base" % "1.4.0-M3-dev-81"
 libraryDependencies += "org.jetbrains.dokka" % "dokka-core" % "1.4.0-M3-dev-81"

--- a/src/main/scala/dotty/dokka/Main.scala
+++ b/src/main/scala/dotty/dokka/Main.scala
@@ -18,7 +18,7 @@ case class DocConfiguration(tastyFiles: List[String], classpath: String)
 object Main:
   def main(args: Array[String]): Unit =
     // TODO #20 change the default to something more reasonable...
-    val cp = args.headOption.getOrElse("target/scala-0.25/classes")
+    val cp = args.headOption.getOrElse("target/scala-0.26/classes")
     def listTastyFiles(f: File): Seq[String] = 
       val (files, dirs) = f.listFiles().partition(_.isFile)
       files.filter(_.getName.endsWith(".tasty")).map(_.toString) ++ dirs.flatMap(listTastyFiles)

--- a/src/main/scala/dotty/dokka/ScalaSignatureProvider.scala
+++ b/src/main/scala/dotty/dokka/ScalaSignatureProvider.scala
@@ -101,7 +101,11 @@ class ScalaSignatureProvider(contentConverter: CommentsToContentConverter, logge
     extension on (builder: PageContentBuilder$DocumentableContentBuilder):
 
         def modifiersAndVisibility[T <: Documentable](t: WithAbstraction with WithVisibility with WithExtraProperties[T], kind: String) =
-            val prefixes = t.getExtra.getMap().asScala.get(AdditionalModifiers.Companion).map(_.asInstanceOf[AdditionalModifiers])
+            import org.jetbrains.dokka.model.properties._
+            val extras = t.getExtra.getMap()
+            val additionalModifiers =
+              Option(extras.get(AdditionalModifiers.Companion).asInstanceOf[AdditionalModifiers])
+            val prefixes = additionalModifiers
                 .map(_.getContent)
                 .map(content => content.defaultValue.asScala.map(_.getName))
                 .map(modifiers => modifiers.toSeq.toSignatureString())

--- a/src/test/scala/dotty/dokka/SingleFileTest.scala
+++ b/src/test/scala/dotty/dokka/SingleFileTest.scala
@@ -51,7 +51,7 @@ abstract class SingleFileTest(val fileName: String, signatureKinds: Seq[String],
       val allFromSource = signaturesFromSource(Source.fromFile(s"src/main/scala/tests/$fileName.scala")).toList
       val fromSource = allFromSource.filter(extractSymbolName(_) != "NULL").map(cleanup)
 
-      val allFromDocumentation = signaturesFromDocumentation(s"target/scala-0.25/classes/tests/$fileName")
+      val allFromDocumentation = signaturesFromDocumentation(s"target/scala-0.26/classes/tests/$fileName")
       val fromDocumentation = allFromDocumentation.filter(extractSymbolName(_) != "NULL").map(cleanup)
       
       val documentedSignature = fromDocumentation.flatMap(matchSignature(_, fromSource)).toSet


### PR DESCRIPTION
A typechecking issue was fixed in between version, so code needed to be changed.

The problem was with the difference of APIs between `java.util.Map` and scala `Map` - the first has a `.get` method that accepts `Object`-s as keys, the second doesn't.