### PR TITLE
Add basic test for enums

### DIFF
--- a/src/main/scala/tests/enums.scala
+++ b/src/main/scala/tests/enums.scala
@@ -1,0 +1,6 @@
+package tests.enums
+
+enum A {
+  case A1
+  case A2
+}

--- a/src/test/scala/dotty/dokka/SignatureTests.scala
+++ b/src/test/scala/dotty/dokka/SignatureTests.scala
@@ -32,4 +32,8 @@ class PackageSymbolSignatures extends SingleFileTest("packageSymbolSignatures", 
 
 class PackageObjectSymbolSignatures extends SingleFileTest("packageObjectSymbolSignatures", SingleFileTest.all.filter(_ != "object"))
 
+class EnumsSignatures extends SingleFileTest("enums", SingleFileTest.all.filter(_ != "object"))
+
+
 class MergedPackageSignatures extends MultipleFileTest(List("mergedPackage1", "mergedPackage2", "mergedPackage3"), List("mergedPackage"), SingleFileTest.all.filter(_ != "object"))
+


### PR DESCRIPTION
When run (e.g. `testOnly dotty.dokka.EnumsSignatures`) produce failure in output:

```
-- Error: src/main/scala/tests/enums.scala:4:2 ---------------------------------
4 |  case A1
  |  ^
  |undefined: reflect.ClassTag.apply # 2134: TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,module class scala)),module reflect),ClassTag),apply) at readTasty
1 error found

```