### PR TITLE
Basic enum support

### DIFF
--- a/src/main/scala/dotty/dokka/ScalaPageCreator.scala
+++ b/src/main/scala/dotty/dokka/ScalaPageCreator.scala
@@ -60,10 +60,10 @@ class ScalaPageCreator(
         
         c match {
             case clazz: DClass => 
-                val op1 = addExtensionMethodPages(clazz, res)
+                val pagesWithExtensions = addExtensionMethodPages(clazz, res)
                 val ext = clazz.get(ClasslikeExtension)
-                if(ext.kind == dotty.dokka.Kind.Object && ext.companion.isDefined) renameCompanionObjectPage(op1)
-                else op1
+                if(ext.kind == dotty.dokka.Kind.Object && ext.companion.isDefined) renameCompanionObjectPage(pagesWithExtensions)
+                else pagesWithExtensions
             case _ => res
         }
     }
@@ -124,10 +124,10 @@ class ScalaPageCreator(
                             builder.unaryPlus(builder.buildSignature(elem))
                             kotlin.Unit.INSTANCE
                         },
-                        dri = Set(elem.getDri).asJava,
+                        dri = JSet(elem.getDri),
                         sourceSets = elem.getSourceSets,
                         kind = ContentKind.SourceSetDependentHint,
-                        styles = Set().asJava
+                        styles = JSet()
                     )
                     kotlin.Unit.INSTANCE
                 }
@@ -172,10 +172,10 @@ class ScalaPageCreator(
                             builder.unaryPlus(builder.buildSignature(elem))
                             kotlin.Unit.INSTANCE
                         },
-                        dri = Set(elem.getDri).asJava,
+                        dri = JSet(elem.getDri),
                         sourceSets = elem.getSourceSets,
                         kind = ContentKind.SourceSetDependentHint,
-                        styles = Set().asJava
+                        styles = JSet()
                     )
                     kotlin.Unit.INSTANCE
                 }
@@ -208,9 +208,9 @@ class ScalaPageCreator(
       
         c match{
             case clazz: DClass =>
-                val op1 = insertCompanion(clazz, defaultContent)
-                val op2 = insertCustomExtensionTab(clazz, op1)
-                if clazz.get(ClasslikeExtension).kind == dotty.dokka.Kind.Enum then insertEnumTab(clazz, op2) else op2
+                val pageWithCompanion = insertCompanion(clazz, defaultContent)
+                val pageWithExtensionsTab = insertCustomExtensionTab(clazz, pageWithCompanion)
+                if clazz.get(ClasslikeExtension).kind == dotty.dokka.Kind.Enum then insertEnumTab(clazz, pageWithExtensionsTab) else pageWithExtensionsTab
             case _ => defaultContent
         }
     }
@@ -323,7 +323,7 @@ class ScalaPageCreator(
                                     //TODO: There's problem with using extra property containers from Dokka in Scala
                                     //val newExtra = if(needsAnchors) then extra.plus(SymbolAnchorHint) else extra
                                     val newExtra = extra
-                                    builder.buildGroup(Set(elem.getDri).asJava, elem.getSourceSets, kind, styles.asJava, newExtra, bdr => { 
+                                    builder.buildGroup(JSet(elem.getDri), elem.getSourceSets, kind, styles.asJava, newExtra, bdr => { 
                                         elementFunc(bdr, elem)
                                         kotlin.Unit.INSTANCE
                                     })

--- a/src/main/scala/dotty/dokka/ScalaPageCreator.scala
+++ b/src/main/scala/dotty/dokka/ScalaPageCreator.scala
@@ -154,13 +154,63 @@ class ScalaPageCreator(
         modifyContentGroup(content, modifiedContent)
     }
 
+    def insertEnumTab(clazz: DClass, defContent: ContentGroup): ContentGroup = {
+        val content = getContentGroupWithParents(defContent, p => p.getStyle.asScala.contains(ContentStyle.TabbedContent))
+        val addedContent = PageContentBuilder(commentsToContentConverter, signatureProvider, logger).contentFor(clazz)(builder => {
+            groupingBlock(
+                builder,
+                "Entries",
+                List(() -> clazz.get(EnumExtension).enumEntries.sortBy(_.getName).toList),
+                (builder, _) => {
+                    kotlin.Unit.INSTANCE
+                },
+                (builder, elem) => {
+                    link(builder, elem.getName, elem.getDri)(kind = ContentKind.Main)
+                    sourceSetDependentHint(builder)( builder =>
+                        {
+                            contentForBrief(builder, elem)
+                            builder.unaryPlus(builder.buildSignature(elem))
+                            kotlin.Unit.INSTANCE
+                        },
+                        dri = Set(elem.getDri).asJava,
+                        sourceSets = elem.getSourceSets,
+                        kind = ContentKind.SourceSetDependentHint,
+                        styles = Set().asJava
+                    )
+                    kotlin.Unit.INSTANCE
+                }
+            )(
+                kind = ContentKind.Main,
+                sourceSets = builder.getMainSourcesetData.asScala.toSet,
+                styles = Set(),
+                extra = PropertyContainer.Companion.empty().plus(SimpleAttr.Companion.header("Entries")),
+                false,
+                true,
+                Nil,
+                false,
+                true
+            )
+            kotlin.Unit.INSTANCE
+        })
+
+        val modifiedContent = content(0).copy(
+            (content(0).getChildren.asScala ++ List(addedContent)).asJava,
+            content(0).getDci,
+            content(0).getSourceSets,
+            content(0).getStyle,
+            content(0).getExtra
+        )
+        modifyContentGroup(content, modifiedContent)
+    }
+
     override def contentForClasslike(c: DClasslike): ContentGroup = {
         val defaultContent = super.contentForClasslike(c)
       
         c match{
             case clazz: DClass =>
                 val op1 = insertCompanion(clazz, defaultContent)
-                insertCustomExtensionTab(clazz, op1)
+                val op2 = insertCustomExtensionTab(clazz, op1)
+                if clazz.get(ClasslikeExtension).kind == dotty.dokka.Kind.Enum then insertEnumTab(clazz, op2) else op2
             case _ => defaultContent
         }
     }

--- a/src/main/scala/dotty/dokka/ScalaSignatureProvider.scala
+++ b/src/main/scala/dotty/dokka/ScalaSignatureProvider.scala
@@ -67,7 +67,18 @@ class ScalaSignatureProvider(contentConverter: CommentsToContentConverter, logge
             builder.addText("case ")
             builder.addLink(entry.getName, entry.getDri)
             builder.addText(" extends ")
-            builder.typeSignature(entry.getType)
+            val modifiedType = entry.getType match{
+                case t: TypeConstructor => TypeConstructor(
+                    t.getDri,
+                    t.getProjections.asScala.map{ 
+                        case t: UnresolvedBound if t.getName == " & " => UnresolvedBound(" with "); 
+                        case other => other
+                    }.asJava,
+                    t.getModifier
+                )
+                case other => other
+            }
+            builder.typeSignature(modifiedType)
 
         }
 

--- a/src/main/scala/dotty/dokka/ScalaSignatureProvider.scala
+++ b/src/main/scala/dotty/dokka/ScalaSignatureProvider.scala
@@ -13,7 +13,6 @@ import org.jetbrains.dokka.model.properties.PropertyContainer
 import dokka.java.api._
 import java.util.function.Consumer
 import kotlin.jvm.functions.Function2
-import java.util.{List => JList}
 
 class ScalaSignatureProvider(contentConverter: CommentsToContentConverter, logger: DokkaLogger) extends SignatureProvider:
     private val default = new KotlinSignatureProvider(contentConverter, logger)
@@ -24,23 +23,23 @@ class ScalaSignatureProvider(contentConverter: CommentsToContentConverter, logge
 
     override def signature(documentable: Documentable) = documentable match {
         case extension: DFunction if extension.get(MethodExtension).extensionInfo.isDefined =>
-            List(extensionSignature(extension)).asJava
+            JList(extensionSignature(extension))
         case method: DFunction =>
-            List(methodSignature(method)).asJava
+            JList(methodSignature(method))
         case enumEntry: DClass if enumEntry.get(IsEnumEntry) != null => 
-            List(enumEntrySignature(enumEntry)).asJava
+            JList(enumEntrySignature(enumEntry))
         case clazz: DClass =>
-            List(classSignature(clazz)).asJava
+            JList(classSignature(clazz))
         case enumProperty: DProperty if enumProperty.get(IsEnumEntry) != null => 
-            List(enumPropertySignature(enumProperty)).asJava
+            JList(enumPropertySignature(enumProperty))
         case property: DProperty =>
-            List(propertySignature(property)).asJava
+            JList(propertySignature(property))
         case parameter: DParameter =>
-            List(parameterSignature(parameter)).asJava
+            JList(parameterSignature(parameter))
         case _ => default.signature(documentable)
     }
 
-    val styles = Set(TextStyle.Monospace).asJava
+    val styles = JSet(TextStyle.Monospace)
 
     val utils: JvmSignatureUtils = KotlinSignatureUtils.INSTANCE
 

--- a/src/main/scala/dotty/dokka/ScalaSignatureProvider.scala
+++ b/src/main/scala/dotty/dokka/ScalaSignatureProvider.scala
@@ -46,14 +46,29 @@ class ScalaSignatureProvider(contentConverter: CommentsToContentConverter, logge
 
     private def enumEntrySignature(entry: DClass): ContentNode =
         content(entry){ builder =>
+            val ext = entry.get(ClasslikeExtension)
             builder.addText("case ")
             builder.addLink(entry.getName, entry.getDri)
-        }
+            builder.generics(entry)
+            ext.constructor.foreach(c => builder.functionParameters(c))
+            ext.parentTypes match 
+                case Nil =>
+                case extendType :: withTypes =>
+                    builder.addText(" extends ") 
+                    builder.typeSignature(extendType)
+                    withTypes.foreach { withType => 
+                        builder.addText(" with ")  
+                        builder.typeSignature(withType)
+                    }
+            }
 
     private def enumPropertySignature(entry: DProperty): ContentNode = 
         content(entry){ builder =>
             builder.addText("case ")
             builder.addLink(entry.getName, entry.getDri)
+            builder.addText(" extends ")
+            builder.typeSignature(entry.getType)
+
         }
 
     private def classSignature(clazz: DClass): ContentNode = 

--- a/src/main/scala/dotty/dokka/ScalaSignatureProvider.scala
+++ b/src/main/scala/dotty/dokka/ScalaSignatureProvider.scala
@@ -27,8 +27,12 @@ class ScalaSignatureProvider(contentConverter: CommentsToContentConverter, logge
             List(extensionSignature(extension)).asJava
         case method: DFunction =>
             List(methodSignature(method)).asJava
+        case enumEntry: DClass if enumEntry.get(IsEnumEntry) != null => 
+            List(enumEntrySignature(enumEntry)).asJava
         case clazz: DClass =>
             List(classSignature(clazz)).asJava
+        case enumProperty: DProperty if enumProperty.get(IsEnumEntry) != null => 
+            List(enumPropertySignature(enumProperty)).asJava
         case property: DProperty =>
             List(propertySignature(property)).asJava
         case parameter: DParameter =>
@@ -39,6 +43,18 @@ class ScalaSignatureProvider(contentConverter: CommentsToContentConverter, logge
     val styles = Set(TextStyle.Monospace).asJava
 
     val utils: JvmSignatureUtils = KotlinSignatureUtils.INSTANCE
+
+    private def enumEntrySignature(entry: DClass): ContentNode =
+        content(entry){ builder =>
+            builder.addText("case ")
+            builder.addLink(entry.getName, entry.getDri)
+        }
+
+    private def enumPropertySignature(entry: DProperty): ContentNode = 
+        content(entry){ builder =>
+            builder.addText("case ")
+            builder.addLink(entry.getName, entry.getDri)
+        }
 
     private def classSignature(clazz: DClass): ContentNode = 
         content(clazz){ builder =>

--- a/src/main/scala/dotty/dokka/scalaModel.scala
+++ b/src/main/scala/dotty/dokka/scalaModel.scala
@@ -19,7 +19,10 @@ case class ParameterExtension(isExtendedSymbol: Boolean, isGrouped: Boolean) ext
 
 object ParameterExtension extends BaseKey[DParameter, ParameterExtension]
 
-class IsEnumEntry extends ExtraProperty[Documentable]:
+enum IsEnumEntry extends ExtraProperty[Documentable]:
+  case Val
+  case Type
+  case Class
   override def getKey = IsEnumEntry
 
 object IsEnumEntry extends BaseKey[Documentable, IsEnumEntry]

--- a/src/main/scala/dotty/dokka/scalaModel.scala
+++ b/src/main/scala/dotty/dokka/scalaModel.scala
@@ -19,13 +19,24 @@ case class ParameterExtension(isExtendedSymbol: Boolean, isGrouped: Boolean) ext
 
 object ParameterExtension extends BaseKey[DParameter, ParameterExtension]
 
+class IsEnumEntry extends ExtraProperty[Documentable]:
+  override def getKey = IsEnumEntry
+
+object IsEnumEntry extends BaseKey[Documentable, IsEnumEntry]
+
 enum Kind(val name: String){
   case Class extends Kind("class")
   case Object extends Kind("object")
   case Trait extends Kind("trait")
+  case Enum extends Kind("enum")
 }
 
 case class ExtensionGroup(val extendedSymbol: DParameter, val extensions: List[DFunction])
+
+case class EnumExtension(val enumEntries: Seq[Documentable]) extends ExtraProperty[DClass]:
+  override def getKey = EnumExtension
+
+object EnumExtension extends BaseKey[DClass, EnumExtension]
 
 case class ClasslikeExtension(
   parentTypes: List[Bound], 
@@ -66,7 +77,7 @@ enum ScalaModifier(val name: String) extends org.jetbrains.dokka.model.Modifier(
   case Abstract extends ScalaModifier("abstract")
   case Final extends ScalaModifier("final")
   case Empty extends ScalaModifier("")
-  
+
 extension (f: DFunction):
   def isRightAssociative(): Boolean = f.getName.endsWith(":")
   def getExtendedSymbol(): Option[DParameter] = Option.when(f.get(MethodExtension).extensionInfo.isDefined)(

--- a/src/main/scala/dotty/dokka/scalaModel.scala
+++ b/src/main/scala/dotty/dokka/scalaModel.scala
@@ -1,11 +1,13 @@
 package dotty.dokka
 
+import org.jetbrains.dokka.DokkaConfiguration$DokkaSourceSet
 import org.jetbrains.dokka.links._
 import org.jetbrains.dokka.model._
 import collection.JavaConverters._
 import org.jetbrains.dokka.links._
 import org.jetbrains.dokka.model.doc._
 import org.jetbrains.dokka.model.properties._  
+
 
 case class ExtensionInformation(val isGrouped: Boolean)
    

--- a/src/main/scala/dotty/dokka/tasty/BasicSupport.scala
+++ b/src/main/scala/dotty/dokka/tasty/BasicSupport.scala
@@ -17,16 +17,16 @@ trait BasicSupport:
   extension (sym: reflect.Symbol):
     def documentation(using cxt: reflect.Context) = sym.comment match 
         case Some(comment) => 
-            sourceSet.asMap(parseComment(comment, sym.tree))
+            Map(sourceSet.getSourceSet -> parseComment(comment, sym.tree))
         case None =>  
-            Map.empty.asJava
+            Map.empty
 
     def source(using ctx: Context) =
       val path = sym.pos.sourceFile.jpath.toString
-      sourceSet.asMap(
+      Map(sourceSet.getSourceSet -> (
         new DocumentableSource:
           override def getPath = path
-      )          
+      ))         
   
   private val emptyDRI =  DRI.Companion.getTopLevel
 

--- a/src/main/scala/dotty/dokka/tasty/BasicSupport.scala
+++ b/src/main/scala/dotty/dokka/tasty/BasicSupport.scala
@@ -64,7 +64,9 @@ class SymOps[R <: Reflection](val r: R) {
         Option.when(sym.flags.is(Flags.Case))(ScalaOnlyModifiers.Case)
       ).flatten
 
-    def shouldDocumentClasslike: Boolean = !sym.flags.is(Flags.Private) && !sym.flags.is(Flags.Synthetic)
+    def shouldDocumentClasslike: Boolean = !sym.flags.is(Flags.Private) && !sym.flags.is(Flags.Synthetic) && (!sym.flags.is(Flags.Case) || !sym.flags.is(Flags.Enum))
+
+    def getCompanionSymbol: Option[Symbol] = Some(sym.companionClass).filter(_.exists)
 
     def isCompanionObject(): Boolean = sym.flags.is(Flags.Object) && sym.companionClass.exists
 

--- a/src/main/scala/dotty/dokka/tasty/ClassLikeSupport.scala
+++ b/src/main/scala/dotty/dokka/tasty/ClassLikeSupport.scala
@@ -116,15 +116,15 @@ trait ClassLikeSupport:
 
     val enumVals = companion.body.collect {
       case td: ValDef if !isSyntheticField(td.symbol, classDef) && td.symbol.flags.is(Flags.Enum) && td.symbol.flags.is(Flags.Case) => td
-    }.toList.map(v => parseValDef(v)).map(p => p.withNewExtras(p.getExtra plus IsEnumEntry()))
+    }.toList.map(v => parseValDef(v)).map(p => p.withNewExtras(p.getExtra plus IsEnumEntry.Val))
 
     val enumTypes = companion.body.collect {
       case td: TypeDef if !td.symbol.flags.is(Flags.Synthetic) && !td.symbol.flags.is(Flags.Private) && td.symbol.flags.is(Flags.Enum) && td.symbol.flags.is(Flags.Case) => td
-    }.toList.map(parseTypeDef).map(p => p.withNewExtras(p.getExtra plus IsEnumEntry()))
+    }.toList.map(parseTypeDef).map(p => p.withNewExtras(p.getExtra plus IsEnumEntry.Type))
 
     val enumNested = companion.body.collect {
       case c: ClassDef if c.symbol.flags.is(Flags.Case) && c.symbol.flags.is(Flags.Enum) => processTree(c)(parseClasslike(c))
-    }.flatten.toList.map(p => p.withNewExtras(p.getExtra plus IsEnumEntry()))
+    }.flatten.toList.map(p => p.withNewExtras(p.getExtra plus IsEnumEntry.Class))
 
     new DClass(
         classDef.symbol.dri,

--- a/src/main/scala/dotty/dokka/tasty/PackageSupport.scala
+++ b/src/main/scala/dotty/dokka/tasty/PackageSupport.scala
@@ -20,7 +20,7 @@ trait PackageSupport:
           Nil.asJava,
           Nil.asJava,
           Nil.asJava,
-          documentation,
+          documentation.asJava,
           null,
           sourceSet.toSet,
           PropertyContainer.Companion.empty()
@@ -36,7 +36,7 @@ trait PackageSupport:
               clazz.getProperties,
               Nil.asJava,
               Nil.asJava,
-              pckObj.symbol.documentation,
+              pckObj.symbol.documentation.asJava,
               null,
               sourceSet.toSet,
               PropertyContainer.Companion.empty()

--- a/src/main/scala/dotty/dokka/tasty/PackageSupport.scala
+++ b/src/main/scala/dotty/dokka/tasty/PackageSupport.scala
@@ -28,7 +28,7 @@ trait PackageSupport:
     }
 
     def parsePackageObject(pckObj: ClassDef): DPackage =
-        parseClass(pckObj) match{
+        parseClasslike(pckObj) match{
           case clazz:DClass =>
             DPackage(
               new DRI(pckObj.symbol.dri.getPackageName, null, null, PointingToDeclaration.INSTANCE, null),

--- a/src/main/scala/dotty/dokka/tasty/TastyParser.scala
+++ b/src/main/scala/dotty/dokka/tasty/TastyParser.scala
@@ -53,7 +53,7 @@ case class TastyParser(reflect: Reflection, inspector: DokkaTastyInspector)
             case packageObject: ClassDef if(packageObject.symbol.name.contains("package$")) =>
               docs += parsePackageObject(packageObject)
             case clazz: ClassDef if clazz.symbol.shouldDocumentClasslike =>
-              docs += parseClass(clazz)
+              docs += parseClasslike(clazz)
             case _ =>  
           }
           seen = seen.tail

--- a/src/main/scala/dotty/dokka/utils.scala
+++ b/src/main/scala/dotty/dokka/utils.scala
@@ -119,3 +119,11 @@ extension on(builder: PageContentBuilder$DocumentableContentBuilder):
             styles: JSet[Style] = builder.getMainStyles,
             extra: PropertyContainer[ContentNode]= builder.getMainExtra) =
             builder.link(text, address, kind, sourceSets, styles, extra)
+
+object JList:
+    def apply[T](elem: T): JList[T] = List(elem).asJava
+    def apply[T]() = List[T]().asJava
+
+object JSet:
+    def apply[T](elem: T): JSet[T] = Set(elem).asJava
+    def apply[T]() = Set[T]().asJava

--- a/src/main/scala/tests/enumSignatures.scala
+++ b/src/main/scala/tests/enumSignatures.scala
@@ -1,0 +1,19 @@
+package tests
+
+package enumSignatures
+
+enum Enum1
+{
+    case A
+    case B
+    case C
+}
+enum Enum2(val i: Int):
+    case A(val s: String) extends Enum2(1)
+    case B(val t: String) extends Enum2(2)
+    case C(val u: String) extends Enum2(3)
+
+enum Enum3(val param: Int):
+    case A extends Enum3(1)
+    case B extends Enum3(2)
+    case C extends Enum3(3)

--- a/src/main/scala/tests/enumSignatures.scala
+++ b/src/main/scala/tests/enumSignatures.scala
@@ -18,4 +18,10 @@ enum Enum3(val param: Int):
     case B extends Enum3(2)
     case C extends Enum3(3)
 
+enum Enum4[+T]:
+    case G(s: String)
+    case B extends Enum4[Int] with A
+    case C[V](s:String) extends Enum4[V]
+    case D[T](s: String) extends Enum4[T]
+
 trait A

--- a/src/main/scala/tests/enumSignatures.scala
+++ b/src/main/scala/tests/enumSignatures.scala
@@ -14,6 +14,8 @@ enum Enum2(val i: Int):
     case C(val u: String) extends Enum2(3)
 
 enum Enum3(val param: Int):
-    case A extends Enum3(1)
+    case A extends Enum3(1) with A
     case B extends Enum3(2)
     case C extends Enum3(3)
+
+trait A

--- a/src/main/scala/tests/fieldsSignatures.scala
+++ b/src/main/scala/tests/fieldsSignatures.scala
@@ -18,8 +18,7 @@ trait C
 
 abstract class D extends C
 {
-  override // TODO #21 override does not work
-  val d: Int
+  override val d: Int
    = 1
 }
 
@@ -31,8 +30,7 @@ trait C2
 
 abstract class D2 extends C
 {
-  override // TODO #21 override does not work
-  val d: Int
+  override val d: Int
   = 1
 }
 

--- a/src/test/scala/dotty/dokka/SignatureTests.scala
+++ b/src/test/scala/dotty/dokka/SignatureTests.scala
@@ -38,3 +38,5 @@ class MergedPackageSignatures extends MultipleFileTest(List("mergedPackage1", "m
 class ExtensionMethodSignature extends SingleFileTest("extensionMethodSignatures", SingleFileTest.all)
 
 class ClassModifiers extends SingleFileTest("classModifiers", SingleFileTest.classlikeKinds)
+
+// class EnumSignatures extends SingleFileTest("enumSignatures", SingleFileTest.all)

--- a/src/test/scala/dotty/dokka/SingleFileTest.scala
+++ b/src/test/scala/dotty/dokka/SingleFileTest.scala
@@ -12,7 +12,7 @@ import scala.jdk.CollectionConverters._
 import scala.math.max
 
 object SingleFileTest {
-  val classlikeKinds = Seq("class",  "object", "trait") // TODO add docs for packages
+  val classlikeKinds = Seq("class",  "object", "trait", "enum") // TODO add docs for packages
   val members = Seq("type", "def", "val", "var")
   val all = classlikeKinds ++ members
 }


### PR DESCRIPTION
closes #64 
It's only basic support that doesn't cover:
```Scala 
case ...(...) extends ...(...) 
```

![image](https://user-images.githubusercontent.com/48246851/89894896-25663f00-dbdb-11ea-8635-1fb7032f730a.png)

However, all tests need to be muted due to problem mentioned here: https://github.com/VirtusLab/dotty-dokka/pull/44
