### PR TITLE
Add Wiki link support to Markdown

### DIFF
--- a/src/main/scala/dotty/dokka/tasty/comments/HtmlParsers.scala
+++ b/src/main/scala/dotty/dokka/tasty/comments/HtmlParsers.scala
@@ -14,6 +14,7 @@ import com.vladsch.flexmark.ext.emoji.EmojiExtension
 import com.vladsch.flexmark.ext.autolink.AutolinkExtension
 import com.vladsch.flexmark.ext.anchorlink.AnchorLinkExtension
 import com.vladsch.flexmark.ext.yaml.front.matter.YamlFrontMatterExtension
+import com.vladsch.flexmark.ext.wikilink.WikiLinkExtension
 import com.vladsch.flexmark.util.options.{ DataHolder, MutableDataSet }
 
 object HtmlParsers {
@@ -28,10 +29,12 @@ object HtmlParsers {
         AnchorLinkExtension.create(),
         EmojiExtension.create(),
         YamlFrontMatterExtension.create(),
-        StrikethroughExtension.create()
+        StrikethroughExtension.create(),
+        WikiLinkExtension.create(),
       ))
       .set(EmojiExtension.ROOT_IMAGE_PATH,
         "https://github.global.ssl.fastly.net/images/icons/emoji/")
+      .set(WikiLinkExtension.LINK_ESCAPE_CHARS, "")
 
   val RENDERER = Formatter.builder(markdownOptions).build()
 

--- a/src/main/scala/dotty/dokka/tasty/comments/package.scala
+++ b/src/main/scala/dotty/dokka/tasty/comments/package.scala
@@ -1,0 +1,14 @@
+package dotty.dokka.tasty.comments
+
+import org.jetbrains.dokka.model.{doc => dkkd}
+
+object kt:
+  import kotlin.collections.builders.{ListBuilder => KtListBuilder, MapBuilder => KtMapBuilder}
+
+  def emptyList[T] = new KtListBuilder[T]().build()
+  def emptyMap[A, B] = new KtMapBuilder[A, B]().build()
+
+object dkk:
+  def text(str: String) =
+    dkkd.Text(str, kt.emptyList, kt.emptyMap)
+

--- a/src/main/scala/tests/tests.scala
+++ b/src/main/scala/tests/tests.scala
@@ -40,9 +40,9 @@ package tests
   *
   * And yet another: [](example.level2.Documentation).
   *
-  * This is my friend: [](tests.B).
+  * This is my friend: [[tests.B]].
   *
-  * And this is his companion: [](tests.B$).
+  * And this is his companion: [[tests.B$ link to the companion]].
   *
   * @author Gal Anonim
   * @version 1.0.0


### PR DESCRIPTION
Add support for Scaladoc wiki-style links `[[link text]]` to Markdown. This is a convenient and backwards-compatible way to link definitions.

Closes #120.