### PR TITLE
SBT plugin basis

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -32,11 +32,22 @@ jobs:
       - name: Compile and test
         run: sbt compile test
 
+      - name: Locally publish Dokka Java API
+        run: |
+          cd dokkaJavaApi
+          ./gradlew publishToMavenLocal
+
+      - name: Locally publish self
+        run: sbt publishLocal
+
       - name: Generate test documentation
         run: sbt generateSelfDocumentation
         
       - name: Generate documentation for dotty library
         run: sbt generateDottyLibDocumentation      
+
+      - name: Generate documentation with SBT plugin
+        run: sbt example-project/doc
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,6 @@
+// re-expose subproject settings
+val `example-project` = ExampleProject.`example-project`
+
 val dottyVersion = "0.27.0-RC1"
 val dokkaVersion = "1.4.0"
 val kotlinxVersion = "0.7.2" // upgrade when upgrading dokka
@@ -34,12 +37,12 @@ lazy val root = project
   .in(file("."))
   .settings(
     name := "scala3doc",
-    version := "0.1.1",
+    version := "0.1.1-SNAPSHOT",
     scalaVersion := dottyVersion
   )
 
 
-val dokkaJavaApiJar = file("libs") / "dokkaJavaApi-0.1.1.jar"
+val dokkaJavaApiJar = file("libs") / "dokkaJavaApi-0.1.1-SNAPSHOT.jar"
 val gradleRootDir = file("dokkaJavaApi")
 
 val buildDokkaApi = taskKey[File]("Compile dokka wrapper and put jar in lib")
@@ -48,7 +51,7 @@ buildDokkaApi := {
   sys.process.Process(Seq("./gradlew", "build"), gradleRootDir).!
 
   if (dokkaJavaApiJar.exists()) IO.delete(dokkaJavaApiJar)
-  IO.move(gradleRootDir / "build" / "libs" / "dokkaJavaApi-0.1.1.jar", dokkaJavaApiJar)
+  IO.move(gradleRootDir / "build" / "libs" / "dokkaJavaApi-0.1.1-SNAPSHOT.jar", dokkaJavaApiJar)
   streams.value.log.success(s"Dokka API copied to $dokkaJavaApiJar")
   dokkaJavaApiJar
 }
@@ -72,6 +75,10 @@ Test / parallelExecution := false
 
 scalacOptions in Compile += "-language:implicitConversions"
 
+Compile / mainClass := Some("dotty.dokka.Main")
+
+// hack, we cannot build documentation so we need this to publish locally
+publishArtifact in (Compile, packageDoc) := false
 
 // TODO #35 proper sbt integration
 val generateDottyLibDocumentation = taskKey[Unit]("Generate documentation for dotty lib")

--- a/dokkaJavaApi/build.gradle.kts
+++ b/dokkaJavaApi/build.gradle.kts
@@ -3,11 +3,12 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     kotlin("jvm") apply false
     id("java")
+    id("maven-publish")
 }
 
 
 group = "org.jetbrains.dokka"
-version = "0.1.1"
+version = "0.1.1-SNAPSHOT"
 
 val language_version: String by project
 
@@ -45,6 +46,17 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            groupId = "scala3doc"
+            artifactId = "dokka-java-api"
+            version = "0.1.1-SNAPSHOT"
+
+            from(components["java"])
+        }
+    }
+}
 
 // Workaround for https://github.com/bintray/gradle-bintray-plugin/issues/267
 //  Manually disable bintray tasks added to the root project

--- a/example-project/.gitignore
+++ b/example-project/.gitignore
@@ -1,0 +1,27 @@
+.DS_Store
+*.class
+*.log
+*~
+
+# sbt specific
+dist/*
+target/
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+project/local-plugins.sbt
+.history
+
+# Scala-IDE specific
+.scala_dependencies
+.cache
+.classpath
+.project
+.settings
+classes/
+
+# idea
+.idea
+.idea_modules
+/.worksheet/

--- a/example-project/.travis.yml
+++ b/example-project/.travis.yml
@@ -1,0 +1,8 @@
+language: scala
+
+jdk:
+  - openjdk8
+
+script:
+  - sbt run
+  - sbt 'set scalaVersion := dottyLatestNightlyBuild.get' run

--- a/example-project/LICENSE
+++ b/example-project/LICENSE
@@ -1,0 +1,25 @@
+Copyright (c) 2015 The dotty-example-project contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. The name of the author may not be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/example-project/README.md
+++ b/example-project/README.md
@@ -1,0 +1,98 @@
+# Example sbt project that compiles using Dotty
+
+[![Build Status](https://travis-ci.org/lampepfl/dotty-example-project.svg?branch=master)](https://travis-ci.org/lampepfl/dotty-example-project)
+
+## Usage
+
+This is a normal sbt project, you can compile code with `sbt compile` and run it
+with `sbt run`, `sbt console` will start a Dotty REPL.
+
+If compiling this example project fails, you probably have a global sbt plugin
+that does not work with dotty, try to disable all plugins in
+`~/.sbt/1.0/plugins` and `~/.sbt/1.0`.
+
+### IDE support
+
+Dotty comes built-in with IDE support, to try it out see
+http://dotty.epfl.ch/docs/usage/ide-support.html
+
+## Making a new Dotty project
+The fastest way to start a new Dotty project is to use one of the following templates:
+* [Simple Dotty project](https://github.com/lampepfl/dotty.g8)
+* [Dotty project that cross-compiles with Scala 2](https://github.com/lampepfl/dotty-cross.g8)
+
+## Using Dotty in an existing project
+
+You will need to make the following adjustments to your build:
+
+### project/plugins.sbt
+```scala
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.4.1")
+```
+
+### project/build.properties
+```scala
+sbt.version=1.3.13
+```
+
+Older versions of sbt are not supported.
+
+
+### build.sbt
+Any version number that starts with `0.` is automatically recognized as Dotty by
+the `sbt-dotty` plugin, you don't need to set up anything:
+
+```scala
+scalaVersion := "0.26.0-RC1"
+```
+
+#### Nightly builds
+If the latest release of Dotty is missing a bugfix or feature you need, you may
+wish to use a nightly build. Look at the bottom of
+https://repo1.maven.org/maven2/ch/epfl/lamp/dotty_0.26/ to find the version
+number for the latest nightly build. Alternatively, you can set `scalaVersion :=
+dottyLatestNightlyBuild.get` to always use the latest nightly build of dotty.
+
+## Getting your project to compile with Dotty
+
+When porting an existing project, it's a good idea to start out with the Scala 2
+compatibility mode (note that this mode affects typechecking and thus may
+prevent some valid Dotty code from compiling) by adding to your `build.sbt`:
+
+```scala
+scalacOptions ++= { if (isDotty.value) Seq("-source:3.0-migration") else Nil }
+```
+
+Using the `isDotty` setting ensures that this option will only be set when
+compiling with Dotty. For more information on the `-source` flag, see
+http://dotty.epfl.ch/docs/usage/language-versions.html, for more information on
+migrating to Scala 3 see [the migration
+guide](https://github.com/scalacenter/scala-3-migration-guide).
+
+If your build contains dependencies that have only been published for Scala 2.x,
+you may be able to get them to work on Dotty by replacing:
+
+```scala
+    libraryDependencies += "a" %% "b" % "c"
+```
+
+by:
+
+```scala
+    libraryDependencies += ("a" %% "b" % "c").withDottyCompat(scalaVersion.value)
+```
+
+This will have no effect when compiling with Scala 2.x, but when compiling
+with Dotty this will change the cross-version to a Scala 2.x one. This
+works because Dotty is currently retro-compatible with Scala 2.x.
+
+Alternatively, to set this setting on all your dependencies, you can use:
+
+```scala
+    libraryDependencies := libraryDependencies.value.map(_.withDottyCompat(scalaVersion.value))
+```
+
+## Discuss
+
+Feel free to come chat with us on the
+[Dotty gitter](http://gitter.im/lampepfl/dotty)!

--- a/example-project/project/build.properties
+++ b/example-project/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.3.13

--- a/example-project/project/plugins.sbt
+++ b/example-project/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.4.1")

--- a/example-project/src/main/scala/AutoParamTupling.scala
+++ b/example-project/src/main/scala/AutoParamTupling.scala
@@ -1,0 +1,25 @@
+package example
+
+/**
+  * Automatic Tupling of Function Params: https://dotty.epfl.ch/docs/reference/other-new-features/auto-parameter-tupling.html
+  */
+object AutoParamTupling {
+
+  def test: Unit = {
+
+    /**
+      * In order to get thread safety, you need to put @volatile before lazy vals.
+      * https://dotty.epfl.ch/docs/reference/changed-features/lazy-vals.html
+      */
+    @volatile lazy val xs: List[String] = List("d", "o", "t", "t", "y")
+
+    /**
+      * Current behaviour in Scala 2.12.2 :
+      * error: missing parameter type
+      * Note: The expected type requires a one-argument function accepting a 2-Tuple.
+      * Consider a pattern matching anonymous function, `{ case (s, i) =>  ... }`
+      */
+    xs.zipWithIndex.map((s, i) => println(s"$i: $s"))
+
+  }
+}

--- a/example-project/src/main/scala/ContextQueries.scala
+++ b/example-project/src/main/scala/ContextQueries.scala
@@ -1,0 +1,48 @@
+package example
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
+
+/**
+  * Context Queries:
+  * - http://dotty.epfl.ch/docs/reference/contextual/query-types.html,
+  * - https://www.scala-lang.org/blog/2016/12/07/implicit-function-types.html
+  */
+object ContextQueries /* Formerly known as Implicit Function Types */ {
+
+  object context {
+    // type alias Contextual
+    type Contextual[T] = ExecutionContext ?=> T
+
+    // sum is expanded to sum(x, y)(ctx)
+    def asyncSum(x: Int, y: Int): Contextual[Future[Int]] = Future(x + y)
+
+    def asyncMult(x: Int, y: Int)(using ctx: ExecutionContext) = Future(x * y)
+  }
+
+  object parse {
+
+    type Parseable[T] = ImpliedInstances.StringParser[T] ?=> Try[T]
+
+    def sumStrings(x: String, y: String): Parseable[Int] = {
+      val parser = implicitly[ImpliedInstances.StringParser[Int]]
+      val tryA = parser.parse(x)
+      val tryB = parser.parse(y)
+
+      for {
+        a <- tryA
+        b <- tryB
+      } yield a + b
+    }
+  }
+
+  def test: Unit = {
+    import ExecutionContext.Implicits.global
+    context.asyncSum(3, 4).foreach(println)
+    context.asyncMult(3, 4).foreach(println)
+
+    println(parse.sumStrings("3", "4"))
+    println(parse.sumStrings("3", "a"))
+  }
+
+}

--- a/example-project/src/main/scala/Conversion.scala
+++ b/example-project/src/main/scala/Conversion.scala
@@ -1,0 +1,39 @@
+package example
+
+import scala.language.implicitConversions
+
+/**
+  *  Conversions: http://dotty.epfl.ch/docs/reference/contextual/conversions.html
+  */
+object Conversion {
+
+  case class IntWrapper(a: Int) extends AnyVal
+  case class DoubleWrapper(b: Double) extends AnyVal
+
+  def convert[T, U](x: T)(using converter: Conversion[T, U]): U = converter(x)
+
+  given IntWrapperToDoubleWrapper as Conversion[IntWrapper, DoubleWrapper] = new Conversion[IntWrapper, DoubleWrapper] {
+    override def apply(i: IntWrapper): DoubleWrapper = new DoubleWrapper(i.a.toDouble)
+  }
+
+  def useConversion(using f: Conversion[IntWrapper, DoubleWrapper]) = {
+    val y: IntWrapper = new IntWrapper(4)
+    val x: DoubleWrapper = y
+    x
+  }
+
+  /* Not working anymore.
+    def useConversion(implicit f: A => B) = {
+      val y: A = ...
+      val x: B = a    // error under Dotty
+    }
+   */
+
+  def test: Unit = {
+    println(useConversion)
+    println(convert(new IntWrapper(42)))
+  }
+
+
+
+}

--- a/example-project/src/main/scala/EnumTypes.scala
+++ b/example-project/src/main/scala/EnumTypes.scala
@@ -1,0 +1,44 @@
+package example
+
+/**
+  * Enum Types: http://dotty.epfl.ch/docs/reference/enums/adts.html
+  */
+object EnumTypes {
+
+  enum ListEnum[+A] {
+    case Cons(h: A, t: ListEnum[A])
+    case Empty
+  }
+
+  enum Planet(mass: Double, radius: Double) {
+    private final val G = 6.67300E-11
+    def surfaceGravity = G * mass / (radius * radius)
+    def surfaceWeight(otherMass: Double) =  otherMass * surfaceGravity
+
+    case Mercury extends Planet(3.303e+23, 2.4397e6)
+    case Venus   extends Planet(4.869e+24, 6.0518e6)
+    case Earth   extends Planet(5.976e+24, 6.37814e6)
+    case Mars    extends Planet(6.421e+23, 3.3972e6)
+    case Jupiter extends Planet(1.9e+27,   7.1492e7)
+    case Saturn  extends Planet(5.688e+26, 6.0268e7)
+    case Uranus  extends Planet(8.686e+25, 2.5559e7)
+    case Neptune extends Planet(1.024e+26, 2.4746e7)
+  }
+
+  def test: Unit = {
+
+    val emptyList = ListEnum.Empty
+    val list = ListEnum.Cons(1, ListEnum.Cons(2, ListEnum.Cons(3, ListEnum.Empty)))
+    println(emptyList)
+    println(s"${list}\n")
+
+    def calculateEarthWeightOnPlanets(earthWeight: Double) = {
+      val mass = earthWeight/Planet.Earth.surfaceGravity
+      for (p <- Planet.values)
+        println(s"Your weight on $p is ${p.surfaceWeight(mass)}")
+    }
+
+    calculateEarthWeightOnPlanets(80)
+  }
+
+}

--- a/example-project/src/main/scala/ImpliedInstances.scala
+++ b/example-project/src/main/scala/ImpliedInstances.scala
@@ -1,0 +1,41 @@
+package example
+
+import scala.util.{Success, Try}
+
+/**
+  * Implied Instances:
+  * - https://dotty.epfl.ch/docs/reference/contextual/instance-defs.html
+  */
+object ImpliedInstances {
+
+  sealed trait StringParser[A] {
+    def parse(s: String): Try[A]
+  }
+
+  object StringParser {
+
+    def apply[A](using parser: StringParser[A]): StringParser[A] = parser
+
+    private def baseParser[A](f: String ⇒ Try[A]): StringParser[A] = new StringParser[A] {
+      override def parse(s: String): Try[A] = f(s)
+    }
+
+    given stringParser as StringParser[String] = baseParser(Success(_))
+    given intParser as StringParser[Int] = baseParser(s ⇒ Try(s.toInt))
+
+    given optionParser[A](using parser: => StringParser[A]) as StringParser[Option[A]] = new StringParser[Option[A]] {
+      override def parse(s: String): Try[Option[A]] = s match {
+        case "" ⇒ Success(None) // implicit parser not used.
+        case str ⇒ parser.parse(str).map(x ⇒ Some(x)) // implicit parser is evaluated at here
+      }
+    }
+  }
+
+  def test: Unit = {
+    println(implicitly[StringParser[Option[Int]]].parse("21"))
+    println(implicitly[StringParser[Option[Int]]].parse(""))
+    println(implicitly[StringParser[Option[Int]]].parse("21a"))
+
+    println(implicitly[StringParser[Option[Int]]](StringParser.optionParser[Int]).parse("42"))
+  }
+}

--- a/example-project/src/main/scala/IntersectionTypes.scala
+++ b/example-project/src/main/scala/IntersectionTypes.scala
@@ -1,0 +1,36 @@
+package example
+
+/**
+  * Intersection Types: https://dotty.epfl.ch/docs/reference/new-types/intersection-types.html
+  */
+object IntersectionTypes {
+
+  sealed trait X {
+    def x: Double
+    def tpe: X
+  }
+
+  sealed trait Y {
+    def y: Double
+    def tpe: Y
+  }
+
+  type P = Y & X
+  type PP = X & Y
+
+  final case class Point(x: Double, y: Double) extends X with Y {
+    override def tpe: X & Y = ???
+  }
+
+  def test: Unit = {
+
+    def euclideanDistance(p1: X & Y, p2: X & Y) = {
+      Math.sqrt(Math.pow(p2.y - p1.y, 2) + Math.pow(p2.x - p1.x, 2))
+    }
+
+    val p1: P = Point(3, 4)
+    val p2: PP = Point(6, 8)
+    println(euclideanDistance(p1, p2))
+
+  }
+}

--- a/example-project/src/main/scala/Main.scala
+++ b/example-project/src/main/scala/Main.scala
@@ -1,0 +1,41 @@
+package example
+
+object Main {
+
+  def main(args: Array[String]): Unit = {
+
+    runExample("Trait Params")(TraitParams.test)
+
+    runExample("Enum Types")(EnumTypes.test)
+
+    runExample("Context Queries")(ContextQueries.test)
+
+    runExample("Implied Instances")(ImpliedInstances.test)
+
+    runExample("Conversion")(Conversion.test)
+
+    runExample("Union Types")(UnionTypes.test)
+
+    runExample("Intersection Types")(IntersectionTypes.test)
+
+    runExample("Type Lambda")(TypeLambdas.test)
+
+    runExample("Multiversal Equality")(MultiversalEquality.test)
+
+    runExample("Named Type Arguments")(NamedTypeArguments.test)
+
+    runExample("Auto Param Tupling")(AutoParamTupling.test)
+
+    runExample("Structural Types")(StructuralTypes.test)
+
+    runExample("Pattern Matching")(PatternMatching.test)
+
+  }
+
+  private def runExample(name: String)(f: => Unit) = {
+    println(Console.MAGENTA + s"$name example:" + Console.RESET)
+    f
+    println()
+  }
+
+}

--- a/example-project/src/main/scala/MultiversalEquality.scala
+++ b/example-project/src/main/scala/MultiversalEquality.scala
@@ -1,0 +1,40 @@
+package example
+
+import scala.language.strictEquality
+
+/**
+  * Multiversal Equality: https://dotty.epfl.ch/docs/reference/contextual/multiversal-equality.html
+  * scala.Eq definition: https://github.com/lampepfl/dotty/blob/master/library/src/scala/Eql.scala
+  */
+object MultiversalEquality {
+
+  def test: Unit = {
+
+    // Values of types Int and String cannot be compared with == or !=,
+    // unless we add the derived delegate instance like:
+    given Eql[Int, String] = Eql.derived
+    println(3 == "3")
+
+    // By default, all numbers are comparable, because of;
+    // implicit def eqlNumber: Eql[Number, Number] = derived
+    println(3 == 5.1)
+
+    // By default, all Sequences are comparable, because of;
+    // implicit def eqlSeq[T, U](implicit eq: Eql[T, U]): Eql[GenSeq[T], GenSeq[U]] = derived
+    println(List(1, 2) == Vector(1, 2))
+
+    class A(a: Int)
+    class B(b: Int)
+
+    val a = new A(4)
+    val b = new B(4)
+
+    // scala.language.strictEquality is enabled, therefore we need some extra delegate instances
+    // to compare instances of A and B.
+    given Eql[A, B] = Eql.derived
+    given Eql[B, A] = Eql.derived
+
+    println(a != b)
+    println(b == a)
+  }
+}

--- a/example-project/src/main/scala/NamedTypeArguments.scala
+++ b/example-project/src/main/scala/NamedTypeArguments.scala
@@ -1,0 +1,32 @@
+package example
+
+/**
+  * Named Type Arguments: https://dotty.epfl.ch/docs/reference/other-new-features/named-typeargs.html
+  */
+object NamedTypeArguments {
+
+  trait Functor[F[_]] {
+    def map[A, B](fa: F[A])(f: A => B): F[B]
+  }
+
+  implicit object listFunctor extends Functor[List] {
+    override def map[A, B](fa: List[A])(f: A => B): List[B] = fa.map(f)
+  }
+
+  def test: Unit = {
+
+    def fmap[F[_], A, B](fa: F[A])(f: A => B)(implicit F: Functor[F]): F[B] = F.map(fa)(f)
+
+    val result: List[Int] = fmap[F = List, A = Int, B = Int](List(1,2,3))(i => i + 1)
+
+    println(result)
+
+    // val notCompile = fmap[F = List, B = String](List(1,2,3))(i => i + 1)
+
+    val compile: List[String] = fmap[F = List, B = String](List(1,2,3))(i => (i + 1).toString)
+
+    println(compile)
+
+  }
+
+}

--- a/example-project/src/main/scala/PatternMatching.scala
+++ b/example-project/src/main/scala/PatternMatching.scala
@@ -1,0 +1,104 @@
+package example
+
+/**
+  * Pattern Matching: https://dotty.epfl.ch/docs/reference/changed-features/pattern-matching.html
+  */
+object PatternMatching {
+
+  object booleanPattern {
+
+    object Even {
+      def unapply(s: String): Boolean = s.length % 2 == 0
+    }
+
+  }
+
+  object productPattern {
+
+    class Person(name: String, age: Int) extends Product {
+      // if we not define that, it will give compile error.
+      // we change the order
+      def _1 = age
+      def _2 = name
+
+      // Not used by pattern matching: Product is only used as a marker trait.
+      def canEqual(that: Any): Boolean = ???
+      def productArity: Int = ???
+      def productElement(n: Int): Any = ???
+    }
+
+    object Person {
+      def unapply(a: (String, Int)): Person = new Person(a._1, a._2)
+    }
+
+  }
+
+  object seqPattern {
+
+    // adapted from http://danielwestheide.com/blog/2012/11/28/the-neophytes-guide-to-scala-part-2-extracting-sequences.html
+    object Names {
+      def unapplySeq(name: String): Option[Seq[String]] = {
+        val names = name.trim.split(" ")
+        if (names.size < 2) None
+        else Some(names.last :: names.head :: names.drop(1).dropRight(1).toList)
+      }
+    }
+
+  }
+
+  object namePattern {
+
+    class Name(val name: String) {
+      def get: String = name
+      def isEmpty = name.isEmpty
+    }
+
+    object Name {
+      def unapply(s: String): Name = new Name(s)
+    }
+
+  }
+
+  def test: Unit = {
+
+    import booleanPattern._
+
+    "even" match {
+      case s @ Even() => println(s"$s has an even number of characters")
+      case s => println(s"$s has an odd number of characters")
+    }
+
+    // http://dotty.epfl.ch/docs/reference/changed/vararg-patterns.html
+    def containsConsecutive(list: List[Int]): Boolean = list match {
+      case List(a, b, xs: _ *) => if (a == b) true else containsConsecutive(b :: xs.toList)
+      case List(a, _ : _*) => false
+      case Nil => false
+    }
+
+    println(containsConsecutive(List(1, 2, 3, 4, 5)))
+    println(containsConsecutive(List(1, 2, 3, 3, 5)))
+
+    import productPattern._
+    ("john", 42) match {
+      case Person(n, a) => println(s"name: $n, age: $a")
+    }
+
+    import seqPattern._
+
+    def greet(fullName: String) = fullName match {
+      case Names(lastName, firstName, _: _*) => "Good morning, " + firstName + " " + lastName + "!"
+      case _ => "Welcome! Please make sure to fill in your name!"
+    }
+
+    println(greet("Alan Turing"))
+    println(greet("john"))
+    println(greet("Wolfgang Amadeus Mozart"))
+
+    import namePattern._
+    "alice" match {
+      case Name(n) => println(s"name is $n")
+      case _ => println("empty name")
+    }
+
+  }
+}

--- a/example-project/src/main/scala/StructuralTypes.scala
+++ b/example-project/src/main/scala/StructuralTypes.scala
@@ -1,0 +1,29 @@
+package example
+
+/**
+  * Structural Types: https://dotty.epfl.ch/docs/reference/changed-features/structural-types.html
+  */
+object StructuralTypes {
+
+  case class Record(elems: (String, Any)*) extends Selectable {
+    def selectDynamic(name: String): Any = elems.find(_._1 == name).get._2
+  }
+
+  type Person = Record {
+    val name: String
+    val age: Int
+  }
+
+  val person = Record("name" -> "Emma", "age" -> 42, "salary" -> 320L).asInstanceOf[Person]
+
+  val invalidPerson = Record("name" -> "John", "salary" -> 42).asInstanceOf[Person]
+
+  def test: Unit = {
+    println(person.name)
+    println(person.age)
+
+    println(invalidPerson.name)
+    // age field is java.util.NoSuchElementException: None.get
+    //println(invalidPerson.age)
+  }
+}

--- a/example-project/src/main/scala/TraitParams.scala
+++ b/example-project/src/main/scala/TraitParams.scala
@@ -1,0 +1,23 @@
+package example
+
+/**
+  * Trait Parameters: https://dotty.epfl.ch/docs/reference/other-new-features/trait-parameters.html
+  */
+object TraitParams {
+
+  trait Base(val msg: String)
+  class A extends Base("Hello")
+  class B extends Base("Dotty!")
+
+  // Union types only exist in Dotty, so there's no chance that this will accidentally be compiled with Scala 2
+  private def printMessages(msgs: (A | B)*) = println(msgs.map(_.msg).mkString(" "))
+
+  def test: Unit = {
+
+    printMessages(new A, new B)
+
+    // Sanity check the classpath: this won't run if the dotty jar is not present.
+    val x: Int => Int = z => z
+    x(1)
+  }
+}

--- a/example-project/src/main/scala/TypeLambdas.scala
+++ b/example-project/src/main/scala/TypeLambdas.scala
@@ -1,0 +1,21 @@
+package example
+
+/**
+  * Type Lambdas: https://dotty.epfl.ch/docs/reference/new-types/type-lambdas.html
+  */
+object TypeLambdas {
+
+  type T[+X, Y] = Map[Y, X]
+
+  type Tuple = [X] =>> (X, X)
+
+  def test: Unit = {
+
+    val m: T[String, Int] = Map(1 -> "1")
+    println(m)
+
+    val tuple: Tuple[String] = ("a", "b")
+    println(tuple)
+  }
+
+}

--- a/example-project/src/main/scala/UnionTypes.scala
+++ b/example-project/src/main/scala/UnionTypes.scala
@@ -1,0 +1,47 @@
+package example
+
+/**
+  * Union Types: https://dotty.epfl.ch/docs/reference/new-types/union-types.html
+  */
+object UnionTypes {
+
+  sealed trait Division
+  final case class DivisionByZero(msg: String) extends Division
+  final case class Success(double: Double) extends Division
+
+  // You can create type aliases for your union types (sum types).
+  type DivisionResult = DivisionByZero | Success
+
+  sealed trait List[+A]
+  final case class Empty() extends List[Nothing]
+  final case class Cons[+A](h: A, t: List[A]) extends List[A]
+
+  private def safeDivide(a: Double, b: Double): DivisionResult = {
+    if (b == 0) DivisionByZero("DivisionByZeroException") else Success(a / b)
+  }
+
+  private def either(division: Division) = division match {
+    case DivisionByZero(m) => Left(m)
+    case Success(d) => Right(d)
+  }
+
+  def test: Unit = {
+
+    val divisionResultSuccess: DivisionResult = safeDivide(4, 2)
+
+    // commutative
+    val divisionResultFailure: Success | DivisionByZero = safeDivide(4, 0)
+
+    // calling `either` function with union typed value.
+    println(either(divisionResultSuccess))
+
+    // calling `either` function with union typed value.
+    println(either(divisionResultFailure))
+
+    val list: Cons[Int] | Empty = Cons(1, Cons(2, Cons(3, Empty())))
+    val emptyList: Empty | Cons[Any] = Empty()
+    println(list)
+    println(emptyList)
+
+  }
+}

--- a/project/ExampleProject.scala
+++ b/project/ExampleProject.scala
@@ -1,0 +1,18 @@
+import sbt._
+import sbt.Keys._
+
+object ExampleProject {
+  import Protoplugin.Keys._
+
+  val `example-project` =
+    project.in(file("example-project"))
+    .settings(Protoplugin.Settings ++ Seq(
+      name := "scala3doc-example-project",
+      description := "Example SBT project that is documented using Scala3doc",
+      version := "0.1.0-SNAPSHOT",
+      scalaVersion := "0.27.0-RC1",
+
+      scala3docOptions ++= Seq("--name", "example-project"),
+      Compile / doc / target := file("output/example-project"),
+    ): _*)
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.0-M2
+sbt.version=1.3.13

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.4.0-M2

--- a/project/protoplugin.scala
+++ b/project/protoplugin.scala
@@ -1,0 +1,171 @@
+import sbt._
+import sbt.Def.Initialize
+import sbt.Keys._
+import sbt.librarymanagement.{
+  ivy, DependencyResolution, ScalaModuleInfo, SemanticSelector, UpdateConfiguration, UnresolvedWarningConfiguration,
+  VersionNumber
+}
+import sbt.internal.inc.ScalaInstance
+
+import java.net.URLClassLoader
+
+object Protoplugin {
+  /** Fetch artifacts for moduleID */
+  def fetchArtifactsOf(
+    moduleID: ModuleID,
+    dependencyRes: DependencyResolution,
+    scalaInfo: Option[ScalaModuleInfo],
+    updateConfig: UpdateConfiguration,
+    warningConfig: UnresolvedWarningConfiguration,
+    log: Logger): UpdateReport = {
+    val descriptor = dependencyRes.wrapDependencyInModule(moduleID, scalaInfo)
+
+    dependencyRes.update(descriptor, updateConfig, warningConfig, log) match {
+      case Right(report) =>
+        report
+      case _ =>
+        throw new MessageOnlyException(
+          s"Couldn't retrieve `$moduleID`.")
+    }
+  }
+
+  /** Get all jars in updateReport that match the given filter. */
+  def getJars(updateReport: UpdateReport, organization: NameFilter, name: NameFilter, revision: NameFilter): Seq[File] = {
+    updateReport.select(
+      configurationFilter(Runtime.name),
+      moduleFilter(organization, name, revision),
+      artifactFilter(extension = "jar", classifier = "")
+    )
+  }
+
+  /** Get the single jar in updateReport that match the given filter.
+    *  If zero or more than one jar match, an exception will be thrown.
+    */
+  def getJar(updateReport: UpdateReport, organization: NameFilter, name: NameFilter, revision: NameFilter): File = {
+    val jars = getJars(updateReport, organization, name, revision)
+    assert(jars.size == 1, s"There should only be one $name jar but found: $jars")
+    jars.head
+  }
+
+  /** Create a scalaInstance task that uses Dotty based on `moduleName`. */
+  def dottyScalaInstanceTask(module: ModuleID): Initialize[Task[ScalaInstance]] = Def.task {
+    val updateReport =
+      fetchArtifactsOf(
+        module,
+        dependencyResolution.value,
+        scalaModuleInfo.value,
+        updateConfiguration.value,
+        (unresolvedWarningConfiguration in update).value,
+        streams.value.log
+      )
+    val scalaLibraryJar = getJar(updateReport,
+      "org.scala-lang", "scala-library", revision = AllPassFilter)
+    val dottyLibraryJar = getJar(updateReport,
+      scalaOrganization.value, s"dotty-library_${scalaBinaryVersion.value}", scalaVersion.value)
+    val compilerJar = getJar(updateReport,
+      scalaOrganization.value, s"dotty-compiler_${scalaBinaryVersion.value}", scalaVersion.value)
+    val allJars =
+      getJars(updateReport, AllPassFilter, AllPassFilter, AllPassFilter)
+
+    val remainingJars =
+      getJars(
+        fetchArtifactsOf(
+          "scala3doc" % "dokka-java-api" % "0.1.1-SNAPSHOT",
+          dependencyResolution.value,
+          scalaModuleInfo.value,
+          updateConfiguration.value,
+          (unresolvedWarningConfiguration in update).value,
+          streams.value.log,
+        ),
+        AllPassFilter, AllPassFilter, AllPassFilter
+      )
+
+    makeScalaInstance(
+      state.value,
+      scalaVersion.value,
+      scalaLibraryJar,
+      dottyLibraryJar,
+      compilerJar,
+      allJars ++ remainingJars,
+    )
+  }
+
+  // Adapted from private mkScalaInstance in sbt
+  def makeScalaInstance(
+    state: State, dottyVersion: String, scalaLibrary: File, dottyLibrary: File, compiler: File, all: Seq[File]
+  ): ScalaInstance = {
+    val libraryLoader = state.classLoaderCache(List(dottyLibrary, scalaLibrary))
+    class DottyLoader
+        extends URLClassLoader(all.map(_.toURI.toURL).toArray, libraryLoader)
+    val fullLoader = state.classLoaderCache.cachedCustomClassloader(
+      all.toList,
+      () => new DottyLoader
+    )
+    new ScalaInstance(
+      dottyVersion,
+      fullLoader,
+      libraryLoader,
+      Array(dottyLibrary, scalaLibrary),
+      compiler,
+      all.toArray,
+      None)
+
+  }
+
+
+  object Keys {
+    lazy val scala3docOptions = settingKey[Seq[String]]("Options for Scala3doc")
+    lazy val serveDoc = taskKey[Unit]("Start a local HTTP server for the documentation")
+    lazy val serveDocPort = settingKey[String]("The port on which serveDoc should run an HTTP server")
+    lazy val serveDocPrimaryExecutable = settingKey[String]("The primary Python executable serveDoc should use")
+    lazy val serveDocSecondaryExecutable = settingKey[String]("The secondary Python executable serveDoc should use")
+  }
+  import Keys._
+
+  lazy val Settings = Seq(
+    resolvers += Resolver.jcenterRepo,
+    resolvers += Resolver.mavenLocal, // necessary for Scala3doc Kotlin code
+    resolvers += Resolver.bintrayRepo("kotlin", "kotlin-dev"),
+    resolvers += Resolver.bintrayRepo("virtuslab", "dokka"),
+    scala3docOptions := Seq.empty,
+    Compile / doc / scalacOptions := {
+      scala3docOptions.value ++ ("--" +: (Compile / doc / scalacOptions).value)
+    },
+    scalaInstance in doc := {
+      dottyScalaInstanceTask(
+        "scala3doc" %% "scala3doc" % "0.1.1-SNAPSHOT",
+      ).value
+    },
+
+    serveDocPort := "8000",
+    serveDocPrimaryExecutable := "python3",
+    serveDocSecondaryExecutable := "python",
+    serveDoc / target := (Compile / doc / target).value,
+    serveDoc := {
+      import scala.sys.process._
+      val log = streams.value.log
+      val port = serveDocPort.value
+      val _target = (serveDoc / target).value
+      def go(exec: String) = {
+        log.info(s"Running a $exec HTTP server at http://localhost:$port in ${_target}")
+        log.info("Press Ctrl-c to interrupt...")
+        Process(
+          Seq(exec, "-m", "http.server", port),
+          _target,
+        ).!
+      }
+
+      val exec = serveDocPrimaryExecutable.value
+      try go(exec)
+      catch {
+        case ex: java.io.IOException =>
+          if (ex.getMessage.contains("No such file or directory")) {
+            val altExec = serveDocSecondaryExecutable.value
+            log.warn(s"Could not find `$exec` executable, retrying with `$altExec` ...")
+            go(altExec)
+          }
+          else throw ex
+      }
+    },
+  )
+}

--- a/project/protoplugin.scala
+++ b/project/protoplugin.scala
@@ -129,7 +129,7 @@ object Protoplugin {
     resolvers += Resolver.bintrayRepo("virtuslab", "dokka"),
     scala3docOptions := Seq.empty,
     Compile / doc / scalacOptions := {
-      scala3docOptions.value ++ ("--" +: (Compile / doc / scalacOptions).value)
+      scala3docOptions.value.map("--+DOC+" + _) ++ (Compile / doc / scalacOptions).value
     },
     scalaInstance in doc := {
       dottyScalaInstanceTask(

--- a/src/main/scala/dotty/tools/dottydoc/Main.scala
+++ b/src/main/scala/dotty/tools/dottydoc/Main.scala
@@ -32,10 +32,14 @@ object Main extends Driver {
   override def process(args: Array[String], rootCtx: Context): Reporter = {
     // split args into ours and Dotty's
     val (dokkaStrArgs, compilerArgs) = {
-      // first "--" arg marks the end of Scala3doc-specific options
-      // it is inserted by SBT plugin
-      val split = args.splitAt(args.indexOf("--"))
-      (split._1, split._2.tail)
+      args.partitionMap { arg =>
+        // our options start with this magic prefix, inserted by the SBT plugin
+        val magicPrefix = "--+DOC+"
+        if arg startsWith magicPrefix then
+          Left(arg stripPrefix magicPrefix)
+        else
+          Right(arg)
+      }
     }
 
     val (filesToCompile, ctx) = setup(compilerArgs, rootCtx)

--- a/src/main/scala/dotty/tools/dottydoc/Main.scala
+++ b/src/main/scala/dotty/tools/dottydoc/Main.scala
@@ -14,8 +14,21 @@ import dotc.config._
 
 import java.io.File
 
+/** Main object for SBT.
+  *
+  * See [[this.process]].
+  */
 object Main extends Driver {
 
+  /** Actual entrypoint from SBT.
+    *
+    * Internal SBT code for `sbt doc` locates this precise method with
+    * reflection, and passes to us both `args` and `rootCtx`. "Internal" here
+    * means that it's painful to modify this code with a plugin.
+    *
+    * `args` contains arguments both for us and for the compiler (see code on
+    * how they're split).
+    */
   override def process(args: Array[String], rootCtx: Context): Reporter = {
     // split args into ours and Dotty's
     val (dokkaStrArgs, compilerArgs) = {

--- a/src/main/scala/dotty/tools/dottydoc/Main.scala
+++ b/src/main/scala/dotty/tools/dottydoc/Main.scala
@@ -1,0 +1,62 @@
+package dotty.tools
+package dottydoc
+
+import dotty.dokka.{Args, RawArgs, DocConfiguration, DottyDokkaConfig}
+
+import org.jetbrains.dokka._
+import org.jetbrains.dokka.utilities._
+import org.jetbrains.dokka.plugability._
+
+import dotc.core.Contexts._
+import dotc.reporting.Reporter
+import dotc.{ Compiler, Driver }
+import dotc.config._
+
+import java.io.File
+
+object Main extends Driver {
+
+  override def process(args: Array[String], rootCtx: Context): Reporter = {
+    // split args into ours and Dotty's
+    val (dokkaStrArgs, compilerArgs) = {
+      // first "--" arg marks the end of Scala3doc-specific options
+      // it is inserted by SBT plugin
+      val split = args.splitAt(args.indexOf("--"))
+      (split._1, split._2.tail)
+    }
+
+    val (filesToCompile, ctx) = setup(compilerArgs, rootCtx)
+    given as Context = ctx
+
+    // parse Dokka args
+    // note: all required args should be set with SBT settings,
+    // to make it easier to set and override them
+    val dokkaArgs = {
+      val dokkaRawArgs = new RawArgs
+      val requiredArgs = Seq(
+        "--tastyRoots", "", // hack, value is not used in SBT but required in CLI
+        // we extract some settings from Dotty options since that's how SBT passes them
+        "--projectTitle", ctx.settings.projectName.value,
+        "--output", ctx.settings.outputDir.value.toString,
+      )
+
+      val parser = org.kohsuke.args4j.CmdLineParser(dokkaRawArgs)
+      try {
+        parser.parseArgument(requiredArgs ++ dokkaStrArgs : _*)
+      } catch {
+        case ex: org.kohsuke.args4j.CmdLineException =>
+          // compiler errors are reported in SBT
+          dotc.report.error(s"Error when parsing Scala3doc options: ${ex.getMessage}")
+          throw ex
+      }
+      dokkaRawArgs.toArgs
+    }
+
+    val config = DocConfiguration.Sbt(dokkaArgs, filesToCompile, ctx)
+    val dokkaCfg = new DottyDokkaConfig(config)
+    new DokkaGenerator(dokkaCfg, DokkaConsoleLogger.INSTANCE).generate()
+
+    rootCtx.reporter
+  }
+
+}

--- a/src/test/scala/dotty/dokka/DottyTestRunner.scala
+++ b/src/test/scala/dotty/dokka/DottyTestRunner.scala
@@ -59,7 +59,7 @@ abstract class DottyAbstractCoreTest extends AbstractCoreTest:
 
         val tastyFiles = tastyDir.split(File.pathSeparatorChar).toList.flatMap(p => listTastyFiles(new File(p))).map(_.toString)
             
-        val config = new DottyDokkaConfig(DocConfiguration(tastyFiles, args))
+        val config = new DottyDokkaConfig(DocConfiguration.Standalone(args, tastyFiles))
         DokkaTestGenerator(
             config,
             new TestLogger(DokkaConsoleLogger.INSTANCE),


### PR DESCRIPTION
This PR adds a sub-project with SBT configuration that makes `sbt doc` use Scala3doc instead of Dottydoc.

The idea is to later on add this SBT configuration to dotty-sbt-plugin.

Closes #70.