### PR TITLE
Comment parser tests

### DIFF
--- a/src/main/scala/dotty/dokka/tasty/ScalaDocSupport.scala
+++ b/src/main/scala/dotty/dokka/tasty/ScalaDocSupport.scala
@@ -31,9 +31,9 @@ trait ScaladocSupport { self: TastyParser =>
 
     val parser = commentSyntax match {
       case CommentSyntax.Wiki =>
-        comments.WikiCommentParser(comments.Repr(reflect)(tree.symbol), ())
+        comments.WikiCommentParser(comments.Repr(reflect)(tree.symbol))
       case CommentSyntax.Markdown =>
-        comments.MarkdownCommentParser(comments.Repr(reflect)(tree.symbol), ())
+        comments.MarkdownCommentParser(comments.Repr(reflect)(tree.symbol))
     }
     val parsed = parser.parse(preparsed)
 

--- a/src/main/scala/dotty/dokka/tasty/comments/Comments.scala
+++ b/src/main/scala/dotty/dokka/tasty/comments/Comments.scala
@@ -6,8 +6,6 @@ import com.vladsch.flexmark.util.{ast => mdu}
 import com.vladsch.flexmark.formatter.Formatter
 import com.vladsch.flexmark.util.options.MutableDataSet
 
-type Packages = Any /* Map[String, EmulatedPackageRepresentation] */
-
 import scala.tasty.Reflection
 class Repr(val r: Reflection)(val sym: r.Symbol)
 
@@ -102,17 +100,17 @@ trait MarkupConversion[T] {
     )
 }
 
-class MarkdownCommentParser(repr: Repr, packages: Packages)
+class MarkdownCommentParser(repr: Repr)
     extends MarkupConversion[mdu.Document] {
 
   def stringToMarkup(str: String) =
-    HtmlParsers.parseToMarkdown(str, repr, packages)
+    MarkdownParser.parseToMarkdown(str)
 
   def markupToDokka(md: mdu.Document) =
-    MarkdownConverter(repr.r)(repr.sym).convertDocument(md)
+    MarkdownConverter(repr).convertDocument(md)
 
   def markupToDokkaCommentBody(md: mdu.Document) =
-    val converter = MarkdownConverter(repr.r)(repr.sym)
+    val converter = MarkdownConverter(repr)
     DokkaCommentBody(
       summary = converter.extractAndConvertSummary(md),
       body = converter.convertDocument(md),
@@ -139,18 +137,17 @@ class MarkdownCommentParser(repr: Repr, packages: Packages)
       .view.mapValues(stringToMarkup).toMap
 }
 
-case class WikiCommentParser(repr: Repr, packages: Packages)
+case class WikiCommentParser(repr: Repr)
     extends MarkupConversion[wiki.Body] {
 
   def stringToMarkup(str: String) =
     wiki.Parser(str).document()
 
   def markupToDokka(body: wiki.Body) =
-    wiki.Converter(repr.r)(repr.sym).convertBody(body)
+    wiki.Converter(repr).convertBody(body)
 
   def markupToDokkaCommentBody(body: wiki.Body) =
-    val converter =
-      wiki.Converter(repr.r)(repr.sym)
+    val converter = wiki.Converter(repr)
     DokkaCommentBody(
       summary = body.summary.map(converter.convertBody),
       body = converter.convertBody(body),
@@ -168,7 +165,7 @@ case class WikiCommentParser(repr: Repr, packages: Packages)
       //   case _ => body
       // }
       // (targetStr, newBody.show(ent))
-      (targetStr, wiki.Converter(repr.r)(repr.sym).convertBody(body))
+      (targetStr, wiki.Converter(repr).convertBody(body))
     }
   }
 

--- a/src/main/scala/dotty/dokka/tasty/comments/MarkdownConverter.scala
+++ b/src/main/scala/dotty/dokka/tasty/comments/MarkdownConverter.scala
@@ -103,9 +103,12 @@ class MarkdownConverter(val repr: Repr) {
           dkkd.A(resolveText(default = target), Map("href" -> "#").asJava)
       })
 
-    case n: mda.Code => emit(dkkd.CodeInline(convertChildren(n).asJava, kt.emptyMap))
+    case n: mda.Code =>
+      emit(dkkd.CodeInline(convertChildren(n).asJava, kt.emptyMap))
     case n: mda.IndentedCodeBlock =>
-      emit(dkkd.CodeBlock(List(dkk.text(n.getChars.toString)).asJava, kt.emptyMap))
+      val bld = new StringBuilder
+      n.getContentLines.asScala.foreach(bld append _)
+      emit(dkkd.CodeBlock(List(dkk.text(bld.toString)).asJava, kt.emptyMap))
     case n: mda.FencedCodeBlock =>
       // n.getInfo - where to stick this?
       emit(dkkd.CodeBlock(convertChildren(n).asJava, kt.emptyMap))

--- a/src/main/scala/dotty/dokka/tasty/comments/MarkdownParser.scala
+++ b/src/main/scala/dotty/dokka/tasty/comments/MarkdownParser.scala
@@ -17,7 +17,7 @@ import com.vladsch.flexmark.ext.yaml.front.matter.YamlFrontMatterExtension
 import com.vladsch.flexmark.ext.wikilink.WikiLinkExtension
 import com.vladsch.flexmark.util.options.{ DataHolder, MutableDataSet }
 
-object HtmlParsers {
+object MarkdownParser {
 
   val markdownOptions: DataHolder =
     new MutableDataSet()
@@ -38,51 +38,10 @@ object HtmlParsers {
 
   val RENDERER = Formatter.builder(markdownOptions).build()
 
-  def parseToMarkdown(
-    text: String,
-    origin: Repr,
-    packages: Packages
-  ): mdu.Document = {
-    import com.vladsch.flexmark.ast.Link
-    import com.vladsch.flexmark.util.ast.{Visitor, VisitHandler, NodeVisitor}
-
-    // val inlineToMarkdown = InlineToMarkdown(origin)
-
-    val node = Parser.builder(markdownOptions)
+  def parseToMarkdown(text: String): mdu.Document =
+    Parser.builder(markdownOptions)
       .build.parse(text).asInstanceOf[mdu.Document]
 
-    def isOuter(url: String) =
-      url.startsWith("http://") ||
-      url.startsWith("https://") ||
-      url.startsWith("ftp://") ||
-      url.startsWith("ftps://")
-
-    def isRelative(url: String) =
-      url.startsWith("../") ||
-      url.startsWith("./")
-
-    // val linkVisitor = new NodeVisitor(
-    //   new VisitHandler(classOf[Link], new Visitor[Link] with MemberLookup {
-    //     def queryToUrl(title: String, link: String) = makeRepresentationLink(origin, packages, Text(title), link).link match {
-    //       case Tooltip(_) => "#"
-    //       case LinkToExternal(_, url) => url
-    //       case LinkToRepresentation(t: Representation) => t match {
-    //         case e: Representation with Members => inlineToMarkdown.relativePath(t)
-    //         case x => x.parentRepresentation.fold("#") { xpar => inlineToMarkdown.relativePath(xpar) }
-    //       }
-    //     }
-
-    //     override def visit(link: Link) = {
-    //       val linkUrl = link.getUrl.toString
-    //       if (!isOuter(linkUrl) && !isRelative(linkUrl))
-    //         link.setUrl(CharSubSequence.of(queryToUrl(link.getTitle.toString, linkUrl)))
-    //     }
-    //   })
-    // )
-
-    // linkVisitor.visit(node)
-    node
-  }
 
   def renderToText(node: mdu.Node): String =
     RENDERER.render(node)

--- a/src/main/scala/dotty/dokka/tasty/comments/package.scala
+++ b/src/main/scala/dotty/dokka/tasty/comments/package.scala
@@ -1,6 +1,9 @@
 package dotty.dokka.tasty.comments
 
+import scala.jdk.CollectionConverters._
+
 import org.jetbrains.dokka.model.{doc => dkkd}
+import com.vladsch.flexmark.util.{ast => mdu}
 
 object kt:
   import kotlin.collections.builders.{ListBuilder => KtListBuilder, MapBuilder => KtMapBuilder}
@@ -12,3 +15,27 @@ object dkk:
   def text(str: String) =
     dkkd.Text(str, kt.emptyList, kt.emptyMap)
 
+object dbg:
+  case class See(n: mdu.Node, c: Seq[See]) {
+    def show(sb: StringBuilder, indent: Int): Unit = {
+      sb ++= " " * indent
+      sb ++= n.toString
+      sb ++= "\n"
+      c.foreach { s => s.show(sb, indent + 2) }
+    }
+
+    override def toString = {
+      val sb = new StringBuilder
+      show(sb, 0)
+      sb.toString
+    }
+  }
+
+  def see(n: mdu.Node): See =
+    See(n, n.getChildIterator.asScala.map(see).toList)
+
+  def parseRaw(str: String) =
+    MarkdownCommentParser(null).stringToMarkup(str)
+
+  def parse(str: String) =
+    parseRaw( Preparser.preparse( Cleaner.clean(str) ).body )

--- a/src/main/scala/dotty/dokka/tasty/comments/package.scala
+++ b/src/main/scala/dotty/dokka/tasty/comments/package.scala
@@ -12,8 +12,37 @@ object kt:
   def emptyMap[A, B] = new KtMapBuilder[A, B]().build()
 
 object dkk:
-  def text(str: String) =
-    dkkd.Text(str, kt.emptyList, kt.emptyMap)
+  def p(children: dkkd.DocTag*) =
+    dkkd.P(children.asJava, Map.empty.asJava)
+  def p(params: (String, String)*)(children: dkkd.DocTag*) =
+    dkkd.P(children.asJava, params.toMap.asJava)
+
+  def text(str: String) = dkkd.Text(str, Nil.asJava, Map.empty.asJava)
+
+  def pre(params: (String, String)*)(children: dkkd.DocTag*) =
+    dkkd.Pre(children.asJava, params.toMap.asJava)
+
+  def codeInline(children: dkkd.DocTag*) =
+    dkkd.CodeInline(children.asJava, Map.empty.asJava)
+  def codeInline(params: (String, String)*)(children: dkkd.DocTag*) =
+    dkkd.CodeInline(children.asJava, params.toMap.asJava)
+  def codeBlock(children: dkkd.DocTag*) =
+    dkkd.CodeBlock(children.asJava, Map.empty.asJava)
+  def codeBlock(params: (String, String)*)(children: dkkd.DocTag*) =
+    dkkd.CodeBlock(children.asJava, params.toMap.asJava)
+
+  def ul(children: dkkd.DocTag*) =
+    dkkd.Ul(children.asJava, Map.empty.asJava)
+  def ul(params: (String, String)*)(children: dkkd.DocTag*) =
+    dkkd.Ul(children.asJava, params.toMap.asJava)
+  def ol(children: dkkd.DocTag*) =
+    dkkd.Ol(children.asJava, Map.empty.asJava)
+  def ol(params: (String, String)*)(children: dkkd.DocTag*) =
+    dkkd.Ol(children.asJava, params.toMap.asJava)
+  def li(children: dkkd.DocTag*) =
+    dkkd.Li(children.asJava, Map.empty.asJava)
+  def li(params: (String, String)*)(children: dkkd.DocTag*) =
+    dkkd.Li(children.asJava, params.toMap.asJava)
 
 object dbg:
   case class See(n: mdu.Node, c: Seq[See]) {

--- a/src/main/scala/dotty/dokka/tasty/comments/wiki/Converter.scala
+++ b/src/main/scala/dotty/dokka/tasty/comments/wiki/Converter.scala
@@ -8,8 +8,13 @@ import org.jetbrains.dokka.model.{doc => dkkd}
 
 import dotty.dokka.tasty.SymOps
 
-class Converter(val r: Reflection)(owner: r.Symbol) {
+class Converter(val repr: Repr) {
   import Emitter._
+
+  // makeshift support for not passing an owner
+  // see same in MarkdownConverter
+  val r: repr.r.type = if repr == null then null else repr.r
+  val owner: r.Symbol = if repr == null then null.asInstanceOf[r.Symbol] else repr.sym
 
   object SymOps extends SymOps[r.type](r)
   import SymOps._

--- a/src/main/scala/dotty/renderers/ScalaHtmlRenderer.scala
+++ b/src/main/scala/dotty/renderers/ScalaHtmlRenderer.scala
@@ -57,6 +57,30 @@ class ScalaHtmlRenderer(ctx: DokkaContext) extends SiteRenderer(ctx) {
         ).toString
     }
 
+    override def buildCodeBlock(
+        f: FlowContent,
+        code: ContentCodeBlock,
+        pageContext: ContentPage,
+    ): Unit = {
+        // we cannot use Scalatags, because we need to call buildContentNode
+        import kotlinx.html.{Gen_consumer_tagsKt => dsl}
+        val c = f.getConsumer
+        val U = kotlin.Unit.INSTANCE
+
+        dsl.div(c, "sample-container", { e =>
+            dsl.pre(c, null, { e =>
+                val codeClass = code.getStyle.asScala.iterator.map(_.toString.toLowerCase).mkString("", " ", " language-scala")
+                dsl.code(c, codeClass, { e =>
+                    e.getAttributes.put("theme", "idea")
+                    code.getChildren.asScala.foreach(buildContentNode(f, _, pageContext, /*sourceSetRestriction*/ null))
+                    U
+                })
+                U
+            })
+            U
+        })
+    }
+
     private def buildWithKotlinx(node: ContentNode, pageContext: ContentPage, sourceSetRestriciton: java.util.Set[DisplaySourceSet]): String = {
         val res = Gen_consumer_tagsKt.div(
             StreamKt.createHTML(true, false),

--- a/src/main/scala/tests/tests.scala
+++ b/src/main/scala/tests/tests.scala
@@ -17,11 +17,13 @@ package tests
   * And this
   * ```scala
   * is.an("actual code block")
+  * with.multiple("lines")
   * ```
   *
   * And this
   *
   *      is.an("indented code block")
+  *      with.multiple("lines")
   *
   * And this
   * > is

--- a/src/main/scala/tests/wiki-tests.scala
+++ b/src/main/scala/tests/wiki-tests.scala
@@ -25,8 +25,8 @@ package tests
   *     - a.c
   *   - b
   *     1. b.1
-  *     2. b.2
-  *     3. b.3
+  *     1. b.2
+  *     1. b.3
   *        a. b.3.a
   *        a. b.3.b
   *         a. b.3.c

--- a/src/test/scala/dotty/dokka/tasty/comments/CommentParserTest.scala
+++ b/src/test/scala/dotty/dokka/tasty/comments/CommentParserTest.scala
@@ -1,0 +1,339 @@
+package dotty.dokka.tasty.comments
+
+import scala.jdk.CollectionConverters._
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+
+import org.jetbrains.dokka.model.{doc => dkkd}
+
+import org.junit.Test
+
+class CommentParserTest {
+  import CommentParserTest._
+
+  @Test def testMdBlockCode(): Unit = {
+    val mdp = MarkdownCommentParser(null)
+    val str = """```scala
+                |is.an("actual code block")
+                |with.multiple("lines")
+                |```""".stripMargin
+
+    val res = mdp.markupToDokka(mdp.stringToMarkup(str))
+    assertSame(res,
+      dkk.p()(dkk.codeBlock()(
+        dkk.text("""is.an("actual code block")
+                   |with.multiple("lines")
+                   |""".stripMargin)
+      )),
+    )
+  }
+
+  @Test def testMdIndentedCode(): Unit = {
+    val mdp = MarkdownCommentParser(null)
+    val str = """    is.an("actual code block")
+                |    with.multiple("lines")""".stripMargin
+
+    val res = mdp.markupToDokka(mdp.stringToMarkup(str))
+    assertSame(res,
+      dkk.p()(dkk.codeBlock()(
+        dkk.text("""is.an("actual code block")
+                   |with.multiple("lines")""".stripMargin)
+      )))
+  }
+
+  @Test def testMdList(): Unit = {
+    val mdp = MarkdownCommentParser(null)
+    val str =
+      """* a
+        |  - a.a
+        |  - a.b
+        |  - a.c
+        |* b
+        |   1. b.1
+        |   1. b.2
+        |   1. b.3
+        |     * b.3.a
+        |     * b.3.b
+        |     * b.3.c""".stripMargin
+
+    val res = mdp.markupToDokka(mdp.stringToMarkup(str))
+    assertSame(res,
+      { import dkk._
+        p(
+          ul(
+            li(
+              p(text("a")),
+              ul(
+                li(p(text("a.a"))),
+                li(p(text("a.b"))),
+                li(p(text("a.c"))),
+            )),
+            li(
+              p(text("b")),
+              ol(
+                li(p(text("b.1"))),
+                li(p(text("b.2"))),
+                li(
+                  p(text("b.3")),
+                  ul(
+                    li(p(text("b.3.a"))),
+                    li(p(text("b.3.b"))),
+                    li(p(text("b.3.c"))),
+        ))))))
+      },
+    )
+  }
+
+  @Test def testWikiList(): Unit = {
+    val mdp = WikiCommentParser(null)
+    val str =
+      """ - a
+        |   - a.a
+        |   - a.b
+        |   - a.c
+        | - b
+        |   1. b.1
+        |   1. b.2
+        |   1. b.3
+        |      a. b.3.a
+        |      a. b.3.b
+        |      a. b.3.c""".stripMargin
+
+    val res = mdp.markupToDokka(mdp.stringToMarkup(str))
+    assertSame(res,
+      { import dkk._
+        p(
+          ul(
+            li(
+              p(text("a")),
+              ul(
+                li(p(text("a.a"))),
+                li(p(text("a.b"))),
+                li(p(text("a.c"))),
+            )),
+            li(
+              p(text("b")),
+              ol(
+                li(p(text("b.1"))),
+                li(p(text("b.2"))),
+                li(
+                  p(text("b.3")),
+                  ol(
+                    li(p(text("b.3.a"))),
+                    li(p(text("b.3.b"))),
+                    li(p(text("b.3.c"))),
+        ))))))
+      },
+    )
+  }
+}
+
+object CommentParserTest {
+
+  enum TagComparison {
+    case OK(self: Class[_], children: List[TagComparison], params: List[ParamComparison])
+    case Mismatch(expCls: Class[_], gotCls: Class[_], gotTag: dkkd.DocTag)
+    case TextOK(text: String, children: List[TagComparison], params: List[ParamComparison])
+    case TextMismatch(expStr: String, gotStr: String)
+    case Missing(tag: dkkd.DocTag)
+    case Extra(tag: dkkd.DocTag)
+  }
+
+  enum ParamComparison {
+    case OK(name: String, value: String)
+    case Mismatch(name: String, exp: String, got: String)
+    case Missing(name: String, value: String)
+    case Extra(name: String, value: String)
+  }
+
+  class TagComparisonBuilder(
+    val parent: Option[TagComparisonBuilder]
+  ) {
+    private var failed: Boolean = false
+    private var abortedWith: Option[TagComparison] = None
+    private val childrenBld: ListBuffer[TagComparison] = ListBuffer.empty
+    private val paramsBld: ListBuffer[ParamComparison] = ListBuffer.empty
+
+    def emit(cmp: ParamComparison): Unit = {
+      cmp match {
+        case _: ParamComparison.OK => ;
+        case _ =>
+          println(s"failed on $cmp")
+          fail()
+      }
+      paramsBld.append(cmp)
+    }
+
+    def emit(cmp: TagComparison): Unit = {
+      cmp match {
+        case _: (TagComparison.OK | TagComparison.TextOK) => ;
+        case _ => fail()
+      }
+      childrenBld.append(cmp)
+    }
+
+    def child: TagComparisonBuilder =
+      TagComparisonBuilder(parent = Some(this))
+
+    def abort(res: TagComparison): Unit = {
+      failed = true
+      abortedWith = Some(res)
+    }
+
+    def fail(): Unit = {
+      failed = true
+      parent.foreach(_.fail())
+    }
+
+    def hasFailed = failed
+
+    def result(exp: dkkd.DocTag) = abortedWith.getOrElse(exp match {
+      case exp: dkkd.Text =>
+        TagComparison.TextOK(exp.getBody, childrenBld.result, paramsBld.result)
+      case exp =>
+        TagComparison.OK(exp.getClass, childrenBld.result, paramsBld.result)
+    })
+  }
+
+  def compareTags(exp: dkkd.DocTag, got: dkkd.DocTag): (TagComparison, Boolean) = {
+    val bld = TagComparisonBuilder(parent = None)
+    doCompareTags(bld)(exp, got)
+    (bld.result(exp), bld.hasFailed)
+  }
+
+  def doCompareTags(bld: TagComparisonBuilder)(exp: dkkd.DocTag, got: dkkd.DocTag): Unit =
+    (exp, got) match {
+      case (_, _) if exp.getClass != got.getClass =>
+        bld.abort(TagComparison.Mismatch(expCls = exp.getClass, gotCls = got.getClass, gotTag = got))
+      case (exp: dkkd.Text, got: dkkd.Text) if exp.getBody != got.getBody =>
+        bld.abort(TagComparison.TextMismatch(expStr = exp.getBody, gotStr = got.getBody))
+      case _ =>
+        val propmap = mutable.Map.empty[String, ParamComparison]
+        got.getParams.asScala.foreach { (k, v) =>
+          propmap(k) = ParamComparison.Extra(k, v)
+        }
+        exp.getParams.asScala.foreach { (k, v) =>
+          propmap.get(k) match {
+            case None =>
+              propmap(k) = ParamComparison.Missing(k, v)
+            case Some(ParamComparison.Extra(_, gotV)) =>
+              if gotV == v then
+                propmap(k) = ParamComparison.OK(k, v)
+              else
+                propmap(k) = ParamComparison.Mismatch(k, exp = v, got = gotV)
+            case other =>
+              sys.error(s"unexpected param comparison: $other")
+          }
+        }
+        propmap.values.foreach(bld.emit)
+        val expIter = exp.getChildren.asScala.iterator
+        val gotIter = got.getChildren.asScala.iterator
+        while expIter.hasNext || gotIter.hasNext do
+          if !expIter.hasNext then
+            bld.emit(TagComparison.Extra(gotIter.next))
+          else if !gotIter.hasNext then
+            bld.emit(TagComparison.Missing(expIter.next))
+          else {
+            val exp = expIter.next
+            val got = gotIter.next
+            val childBld = bld.child
+            doCompareTags(childBld)(exp, got)
+            // val cmp = childBld.result match {
+            //   case Left(cmp) => cmp
+            //   case Right((children, params)) =>
+            //     exp match {
+            //       case exp: dkkd.Text =>
+            //         TagComparison.TextOK(exp.getBody, children, params)
+            //       case exp =>
+            //         TagComparison.OK(exp.getClass, children, params)
+            //     }
+            // }
+            bld.emit(bld.result(exp))
+          }
+    }
+
+
+  def doRender(bld: StringBuilder, indent: Int)(cmp: TagComparison): Unit = {
+    def doIndent(ind: Int = indent): Unit =
+      bld ++= " " * ind
+
+    def doLn(ln: String, ind: Int = indent): Unit =
+      doIndent(ind)
+      bld ++= ln
+      bld += '\n'
+
+    def doText(text: String, ind: Int = indent): Unit =
+      var firstLine = true
+      text.linesIterator.foreach { ln =>
+        if !firstLine then bld ++= "\n" else firstLine = false
+        doIndent(ind)
+        bld ++= ln
+        bld
+      }
+
+    def renderTag(indent: Int)(tag: dkkd.DocTag): Unit = {
+      tag match {
+        case tag: dkkd.Text =>
+          doLn("Text:", indent)
+          doText(tag.getBody, indent + 2)
+        case tag =>
+          doIndent(indent)
+          bld ++= tag.getClass.getSimpleName
+          bld ++= "(\n"
+          var firstChild = true
+          tag.getChildren.asScala.foreach { c =>
+            if !firstChild then bld += '\n' else firstChild = false
+            renderTag(indent + 2)(c)
+          }
+          bld ++= "\n"
+          doIndent(indent)
+          bld ++= ")"
+      }
+    }
+
+    cmp match {
+      case TagComparison.TextOK(text, children, props) =>
+        doLn("Text:")
+        doText(text, indent + 2)
+      case TagComparison.TextMismatch(expStr, gotStr) =>
+        doLn("!!! MISMATCH: Text:")
+        doLn("Expected:", indent + 2)
+        doText(expStr, indent + 4)
+        bld += '\n'
+        doLn("Got:", indent + 2)
+        doText(gotStr, indent + 4)
+      case TagComparison.OK(cls, children, props) =>
+        doIndent()
+        bld ++= cls.getSimpleName
+        bld ++= "(\n"
+        var firstChild = true
+        children.foreach { c =>
+          if !firstChild then bld += '\n' else firstChild = false
+          doRender(bld, indent + 2)(c)
+        }
+        bld ++= "\n"
+        doIndent()
+        bld ++= ")"
+      case TagComparison.Mismatch(expCls, gotCls, gotTag) =>
+        doLn(s"!!! MISMATCH: expected=${expCls.getSimpleName}, got=${gotCls.getSimpleName}, tag:\n")
+        renderTag(indent + 2)(gotTag)
+      case TagComparison.Extra(tag) =>
+        doLn(s"!!! EXTRA:")
+        renderTag(indent + 2)(tag)
+      case TagComparison.Missing(tag) =>
+        doLn(s"!!! MISSING:")
+        renderTag(indent + 2)(tag)
+    }
+  }
+
+  def assertSame(got: dkkd.DocTag, exp: dkkd.DocTag, explode: Boolean = false) = {
+    val (comparison, failure) = compareTags(exp, got)
+    if explode || failure then {
+      val bld = new StringBuilder
+      bld += '\n'
+      doRender(bld, indent = 0)(comparison)
+      bld += '\n'
+      throw new java.lang.AssertionError(bld.toString)
+    }
+  }
+}


### PR DESCRIPTION
Fixes #127, improves Wiki nested lists.

https://scala3doc.s3.eu-central-1.amazonaws.com/pr-165/stdLib/dotty-lib/scala/tasty/-reflection/index.html shows the improved appearance of code blocks.

There are still bugs with how nested lists look (https://scala3doc.s3.eu-central-1.amazonaws.com/pr-165/self/scala3doc/tests/-md-lists/index.html , https://scala3doc.s3.eu-central-1.amazonaws.com/pr-165/self/scala3doc/tests/-wiki-lists/index.html) and tracking down where the issue happens is quite difficult. By now I think the bug not in our code that creates DocTags nor in the Dokka code that turns them into ContentNodes, but in HtmlRenderer.