### PR TITLE
Increase Scaladoc-compat of member lookup

### DIFF
--- a/src/main/scala/dotty/dokka/DottyDokkaPlugin.scala
+++ b/src/main/scala/dotty/dokka/DottyDokkaPlugin.scala
@@ -24,7 +24,7 @@ import org.jetbrains.dokka.pages._
   * Wires together classes responsible for consuming Tasty and generating
   * documentation.
   *
-  * Most of the work of parsing Tasty is done by [](DokkaTastyInspector).
+  * Most of the work of parsing Tasty is done by [[DokkaTastyInspector]].
   */
 class DottyDokkaPlugin extends JavaDokkaPlugin:
   override def createSourceToDocumentableTranslator(cxt: DokkaContext, sourceSet: SourceSetWrapper): DModule = cxt.getConfiguration match {

--- a/src/main/scala/dotty/dokka/tasty/TastyParser.scala
+++ b/src/main/scala/dotty/dokka/tasty/TastyParser.scala
@@ -21,7 +21,7 @@ import scala.tasty.inspector.TastyInspector
 
 /** Responsible for collectively inspecting all the Tasty files we're interested in.
   *
-  * Delegates most of the work to [](TastyParser) [](dotty.dokka.tasty.TastyParser).
+  * Delegates most of the work to [[TastyParser]] [[dotty.dokka.tasty.TastyParser]].
   */
 case class DokkaTastyInspector(sourceSet: SourceSetWrapper, parser: Parser, config: DottyDokkaConfig) extends DokkaBaseTastyInspector with TastyInspector
 

--- a/src/main/scala/dotty/dokka/tasty/comments/BaseConverter.scala
+++ b/src/main/scala/dotty/dokka/tasty/comments/BaseConverter.scala
@@ -1,0 +1,22 @@
+package dotty.dokka.tasty.comments
+
+import scala.jdk.CollectionConverters._
+
+import org.jetbrains.dokka.model.{doc => dkkd}
+
+/** Quick'n'dirty class to remove some code duplication */
+trait BaseConverter {
+
+  protected def withParsedQuery(queryStr: String)(thunk: Query => dkkd.DocTag): dkkd.DocTag = {
+    QueryParser(queryStr).tryReadQuery() match {
+      case Left(err) =>
+        // TODO: for better experience we should show source location here
+        println("WARN: " + err.getMessage)
+        dkkd.A(List(dkk.text(err.getMessage)).asJava, Map("href" -> "#").asJava)
+      case Right(query) =>
+        thunk(query)
+    }
+  }
+
+  protected val SchemeUri = """[a-z]+:.*""".r
+}

--- a/src/main/scala/dotty/dokka/tasty/comments/MarkdownConverter.scala
+++ b/src/main/scala/dotty/dokka/tasty/comments/MarkdownConverter.scala
@@ -11,7 +11,7 @@ import com.vladsch.flexmark.ext.{wikilink => mdw}
 
 import dotty.dokka.tasty.SymOps
 
-class MarkdownConverter(val repr: Repr) {
+class MarkdownConverter(val repr: Repr) extends BaseConverter {
   import Emitter._
 
   // makeshift support for not passing an owner
@@ -66,7 +66,6 @@ class MarkdownConverter(val repr: Repr) {
       })
 
     case n: mda.Link =>
-      val SchemeUri = """[a-z]+:.*""".r
       val userText: String = n.getText.toString
       val target: String = n.getUrl.toString
       def resolveText(default: String) =
@@ -76,31 +75,36 @@ class MarkdownConverter(val repr: Repr) {
       emit(target match {
         case SchemeUri() =>
           dkkd.A(resolveText(default = target), Map("href" -> target).asJava)
-        case _ => MemberLookup.lookup(using r)(target, owner) match {
-          case Some((sym, targetText)) =>
-            dkkd.DocumentationLink(sym.dri, resolveText(default = targetText), kt.emptyMap)
-          case None =>
-            dkkd.A(resolveText(default = target), Map("href" -> "#").asJava)
-        }
+        case _ =>
+          withParsedQuery(target) { query =>
+            MemberLookup.lookup(using r)(query, owner) match {
+              case Some((sym, targetText)) =>
+                dkkd.DocumentationLink(sym.dri, resolveText(default = targetText), kt.emptyMap)
+              case None =>
+                dkkd.A(resolveText(default = target), Map("href" -> "#").asJava)
+            }
+          }
       })
 
     case n: mdw.WikiLink =>
       val (target, userText) =
-        val chars: String = n.getChars.toString
-        chars.substring(2, chars.length - 2).split(" ", /*max*/ 2) match {
-          case Array(s) => (s, "")
-          case Array(s1, s2) => (s1, s2)
+        val chars = n.getChars.toString.substring(2, n.getChars.length - 2)
+        chars.split(" ", /*max*/ 2) match {
+          case Array(target) => (target, "")
+          case Array(target, userText) => (target, userText)
         }
 
       def resolveText(default: String) =
         val resolved = if !userText.isEmpty then userText else default
         List(dkk.text(resolved)).asJava
 
-      emit(MemberLookup.lookup(using r)(target, owner) match {
-        case Some((sym, targetText)) =>
-          dkkd.DocumentationLink(sym.dri, resolveText(default = targetText), kt.emptyMap)
-        case None =>
-          dkkd.A(resolveText(default = target), Map("href" -> "#").asJava)
+      emit(withParsedQuery(target) { query =>
+        MemberLookup.lookup(using r)(query, owner) match {
+          case Some((sym, targetText)) =>
+            dkkd.DocumentationLink(sym.dri, resolveText(default = targetText), kt.emptyMap)
+          case None =>
+            dkkd.A(resolveText(default = query.join), Map("href" -> "#").asJava)
+        }
       })
 
     case n: mda.Code =>

--- a/src/main/scala/dotty/dokka/tasty/comments/MemberLookup.scala
+++ b/src/main/scala/dotty/dokka/tasty/comments/MemberLookup.scala
@@ -89,27 +89,6 @@ trait MemberLookup {
       def hackResolveModule(s: r.Symbol): r.Symbol =
         if s.flags.is(Flags.Object) then s.moduleClass else s
 
-      // var candidate: Option[r.Symbol] = None
-      // var continue: Boolean = true
-      // while syms.hasNext && continue do {
-      //   val s = syms.next()
-      //   if s.name == q then
-      //     if forceTerm then
-      //       if s.isTerm then
-      //         candidate = Some(s)
-      //         continue = false
-      //     else if forceType then
-      //       if s.isType then
-      //         candidate = Some(s)
-      //         continue = false
-      //     else
-      //       if s.isType then
-      //         candidate = Some(s)
-      //         continue = false
-      //       else if candidate.isEmpty then
-      //         candidate = Some(s)
-      // }
-
       val matched = syms.find(matches)
 
       // def showMatched() = matched.foreach { s =>

--- a/src/main/scala/dotty/dokka/tasty/comments/Queries.scala
+++ b/src/main/scala/dotty/dokka/tasty/comments/Queries.scala
@@ -1,0 +1,144 @@
+package dotty.dokka.tasty.comments
+
+sealed trait Query {
+  def asList: List[String] = this match {
+    case Query.StrictMemberId(id) => id :: Nil
+    case Query.Id(id) => id :: Nil
+    case Query.QualifiedId(qual, _, rest) => qual.asString :: rest.asList
+  }
+
+  def join: String =
+    def go(sb: StringBuilder, segment: Query): String = segment match {
+      case Query.StrictMemberId(id) =>
+        sb ++= id
+        sb.toString
+      case Query.Id(id) =>
+        sb ++= id
+        sb.toString
+      case Query.QualifiedId(qual, sep, rest) =>
+        sb ++= qual.asString
+        sb += sep
+        go(sb, rest)
+    }
+    go(new StringBuilder, this)
+}
+
+sealed trait QuerySegment extends Query
+object Query {
+  case class StrictMemberId(id: String) extends Query
+  case class Id(id: String) extends QuerySegment
+  case class QualifiedId(id: Qual, sep: Char, rest: QuerySegment) extends QuerySegment
+
+  enum Qual {
+    case Id(id: String)
+    case This
+    case Package
+
+    def asString: String = this match {
+      case Qual.This => "this"
+      case Qual.Package => "package"
+      case Qual.Id(id) => id
+    }
+  }
+}
+
+class QueryParser(val query: CharSequence) {
+  private var idx = 0
+  private var bld: StringBuilder = StringBuilder()
+
+  def tryReadQuery(): Either[QueryParseException, Query] =
+    try Right(readQuery()) catch {
+      case ex : QueryParseException => Left(ex)
+    }
+
+  def readQuery(): Query = {
+    assertBounds("expected start of query")
+    if lookingAt('#') then {
+      popCh()
+      val res = readIdentifier().asString
+      Query.StrictMemberId(res)
+    } else readSegmentedQuery()
+  }
+
+  def readSegmentedQuery(): QuerySegment = {
+    val id = readIdentifier()
+    if atEnd() || lookingAt('(') || lookingAt('[') then {
+      Query.Id(id.asString)
+    } else {
+      val ch = popCh()
+      if ch == '.' || ch == '#'
+      then Query.QualifiedId(id, ch, readSegmentedQuery())
+      else err(s"expected . or #, instead saw: '$ch'")
+    }
+  }
+
+  def readIdentifier(): Query.Qual = {
+    assertBounds("expected start of identifier")
+    if lookingAt('`') then {
+      popCh()
+      readQuotedIdentifier()
+    } else readSimpleIdentifier()
+  }
+
+  def readSimpleIdentifier(): Query.Qual = {
+    def atEndOfId(): Boolean =
+      atEnd() || {
+        if lookingAt('`') then err("backquotes are not allowed in identifiers")
+        lookingAt('#') || lookingAt('.')
+          || lookingAt('(') || lookingAt('[')
+      }
+
+    while !atEndOfId() do pull()
+    val res = popRes()
+    if res.isEmpty then err("empty identifier")
+    res match {
+      case "this" => Query.Qual.This
+      case "package" => Query.Qual.Package
+      case res => Query.Qual.Id(res)
+    }
+  }
+
+  def readQuotedIdentifier(): Query.Qual = {
+    while {
+      assertBounds("unexpected end of quoted identifier (expected '`')")
+      !lookingAt('`')
+    } do pull()
+    popCh()
+    val res = popRes()
+    if res.isEmpty then err("empty quoted identifier")
+    Query.Qual.Id(res)
+  }
+
+  private def popCh(): Char = {
+    val res = query.charAt(idx)
+    idx += 1
+    res
+  }
+
+  private def popRes(): String = {
+    val res = bld.toString
+    bld = StringBuilder()
+    res
+  }
+
+  private def pull(): Unit = {
+    bld += query.charAt(idx)
+    idx += 1
+  }
+
+  private def lookingAt(char: Char) = query.charAt(idx) == char
+
+  private def atEnd() = idx >= query.length
+
+  private def assertBounds(context: String) =
+    if idx >= query.length then err(context)
+
+  private def err(problem: String) =
+    throw new QueryParseException(query, idx, problem)
+
+  class QueryParseException(
+    val query: CharSequence,
+    val at: Int,
+    val problem: String
+  ) extends Exception(s"$problem at char $at in query: $query")
+}

--- a/src/main/scala/dotty/dokka/tasty/comments/wiki/Converter.scala
+++ b/src/main/scala/dotty/dokka/tasty/comments/wiki/Converter.scala
@@ -107,7 +107,6 @@ class Converter(val repr: Repr) extends BaseConverter {
     case Underline(text) => emit(dkkd.U(convertInline(text).asJava, kt.emptyMap))
     case Monospace(text) => emit(dkkd.CodeInline(convertInline(text).asJava, kt.emptyMap))
     case Link(target, userText) =>
-      val SchemeUri = """[a-z]+:.*""".r
       def resolveText(default: String) =
         if !userText.isEmpty
         then convertInline(userText).asJava

--- a/src/main/scala/dotty/dokka/tasty/comments/wiki/Converter.scala
+++ b/src/main/scala/dotty/dokka/tasty/comments/wiki/Converter.scala
@@ -8,7 +8,7 @@ import org.jetbrains.dokka.model.{doc => dkkd}
 
 import dotty.dokka.tasty.SymOps
 
-class Converter(val repr: Repr) {
+class Converter(val repr: Repr) extends BaseConverter {
   import Emitter._
 
   // makeshift support for not passing an owner
@@ -116,12 +116,15 @@ class Converter(val repr: Repr) {
       emit(target match {
         case SchemeUri() =>
           dkkd.A(resolveText(default = target), Map("href" -> target).asJava)
-        case _ => MemberLookup.lookup(using r)(target, owner) match {
-          case Some((sym, targetText)) =>
-            dkkd.DocumentationLink(sym.dri, resolveText(default = targetText), kt.emptyMap)
-          case None =>
-            dkkd.A(resolveText(default = target), Map("href" -> "#").asJava)
-        }
+        case _ =>
+          withParsedQuery(target) { query =>
+            MemberLookup.lookup(using r)(query, owner) match {
+              case Some((sym, targetText)) =>
+                dkkd.DocumentationLink(sym.dri, resolveText(default = targetText), kt.emptyMap)
+              case None =>
+                dkkd.A(resolveText(default = target), Map("href" -> "#").asJava)
+            }
+          }
       })
 
     case _: (Superscript | Subscript | RepresentationLink | HtmlTag) =>

--- a/src/main/scala/tests/tests.scala
+++ b/src/main/scala/tests/tests.scala
@@ -30,21 +30,21 @@ package tests
   * > > a
   * > blockquote
   *
-  * And this is a link: [](method).
+  * And this is a link: [[method]].
   *
   * This is another way to spell the same link: [[#method]].
   *
-  * And this is another link: [](AA).
+  * And this is another link: [[AA]].
   *
-  * And this is another link: [](AA$).
+  * And this is another link: [[AA$]].
   *
-  * And this is yet another link: [](tests.Methods).
+  * And this is yet another link: [[tests.Methods]].
   *
-  * Yet another: [](tests.Methods.simple).
+  * Yet another: [[tests.Methods.simple]].
   *
-  * And yet another: [](example.level2.Documentation).
+  * And yet another: [[example.level2.Documentation]].
   *
-  * This is my friend: [[tests.B]].
+  * This is my friend: [[tests\.B\]]].
   *
   * And this is his companion: [[tests.B$ link to the companion]].
   *
@@ -110,13 +110,13 @@ class B extends A {
 
 /** Companion object to test linking.
   *
-  * This is my member: [](B$.Z)
+  * This is my member: [[B$.Z]]
   *
-  * And this is my term member: [](B$.Z$)
+  * And this is my term member: [[B$.Z$]]
   *
-  * This is my member, addressed differently: [](this.Z)
+  * This is my member, addressed differently: [[this.Z]]
   *
-  * And this is my term member, addressed differently: [](this.Z$)
+  * And this is my term member, addressed differently: [[this.Z$]]
   */
 object B {
   type Z = Int

--- a/src/main/scala/tests/tests.scala
+++ b/src/main/scala/tests/tests.scala
@@ -32,6 +32,8 @@ package tests
   *
   * And this is a link: [](method).
   *
+  * This is another way to spell the same link: [[#method]].
+  *
   * And this is another link: [](AA).
   *
   * And this is another link: [](AA$).
@@ -52,7 +54,15 @@ package tests
   * @constructor A class has a constructor, and this one is important.
   */
 class A {
-  /** This is a method. */
+
+  /** This is a method.
+    *
+    * This is a link: [[AA]].
+    *
+    * This is another link: [[AA$]].
+    *
+    * And yet another: [[B]].
+    */
   def method(s: String): String = s
 
   class AA
@@ -113,7 +123,10 @@ object B {
   val Z: Int = 0
 }
 
-class C 
+class C {
+  object CC
+  class CC
+}
 class D[T]
 class E[T] extends D[T]
 

--- a/src/test/scala/dotty/dokka/tasty/comments/MarkdownConverterTests.scala
+++ b/src/test/scala/dotty/dokka/tasty/comments/MarkdownConverterTests.scala
@@ -1,0 +1,12 @@
+package dotty.dokka.tasty.comments
+
+import org.junit.{Test, Rule}
+import org.junit.Assert.{assertSame, assertTrue, assertEquals}
+
+class MarkdownConverterTests {
+  @Test def test(): Unit = {
+    assertEquals(("a", "b c d"), MarkdownConverter.splitWikiLink("a b c d"))
+    assertEquals(("a", "b\\ c d"), MarkdownConverter.splitWikiLink("a b\\ c d"))
+    assertEquals(("a\\ b", "c d"), MarkdownConverter.splitWikiLink("a\\ b c d"))
+  }
+}

--- a/src/test/scala/dotty/dokka/tasty/comments/MemberLookupTests.scala
+++ b/src/test/scala/dotty/dokka/tasty/comments/MemberLookupTests.scala
@@ -1,0 +1,145 @@
+package dotty.dokka.tasty.comments
+
+import scala.tasty.Reflection
+
+import org.junit.{Test, Rule}
+import org.junit.Assert.{assertSame, assertTrue}
+
+class LookupTestCases[R <: Reflection](val r: R) {
+
+  def testAll(): Unit = {
+    testOwnerlessLookup()
+    testOwnedLookup()
+    testStrictMemberLookup()
+  }
+
+  def testOwnerlessLookup(): Unit = {
+    val cases = List[(String, Sym)](
+      "tests.A" -> cls("tests.A"),
+      "tests.A$" -> cls("tests.A$"),
+      "tests.Methods.simple" -> cls("tests.Methods").fun("simple"),
+    )
+
+    cases.foreach { case (query, Sym(sym)) =>
+      val Some((lookedUp, _)) = MemberLookup.lookupOpt(parseQuery(query), None)
+      assertSame(query, sym, lookedUp)
+    }
+  }
+
+  def testOwnedLookup(): Unit = {
+    val cases = List[((Sym, String), Sym)](
+      cls("tests.A") -> "tests.Methods.simple" -> cls("tests.Methods").fun("simple"),
+      cls("tests.A") -> "tests#Methods#simple" -> cls("tests.Methods").fun("simple"),
+
+      cls("tests.A") -> "method" -> cls("tests.A").fun("method"),
+      cls("tests.A") -> "#method" -> cls("tests.A").fun("method"),
+      cls("tests.A") -> "method*" -> cls("tests.A").fun("method"),
+      cls("tests.A") -> "method[T]*" -> cls("tests.A").fun("method"),
+      cls("tests.A") -> "method(str:String*" -> cls("tests.A").fun("method"),
+
+      cls("tests.A") -> "tests.B" -> cls("tests.B"),
+      cls("tests.A") -> "tests.B$" -> cls("tests.B$"),
+
+      cls("tests.A") -> "AA" -> cls("tests.A").tpe("AA"),
+      cls("tests.A") -> "#AA" -> cls("tests.A").tpe("AA"),
+      cls("tests.A") -> "AA!" -> cls("tests.A").tpe("AA"),
+      cls("tests.A") -> "AA$" -> cls("tests.A").fld("AA"),
+
+      cls("tests.C") -> "CC" -> cls("tests.C").fld("CC"),
+      cls("tests.C") -> "CC$" -> cls("tests.C").fld("CC"),
+      cls("tests.C") -> "CC!" -> cls("tests.C").tpe("CC"),
+
+      cls("tests.A").fun("method") -> "AA" -> cls("tests.A").tpe("AA"),
+      cls("tests.A").fun("method") -> "AA!" -> cls("tests.A").tpe("AA"),
+      cls("tests.A").fun("method") -> "AA$" -> cls("tests.A").fld("AA"),
+
+      cls("tests.Methods").fun("simple") -> "generic" -> cls("tests.Methods").fun("generic"),
+      cls("tests.Methods").fun("simple") -> "#generic" -> cls("tests.Methods").fun("generic"),
+
+      cls("tests.A").fun("method") -> "B" -> cls("tests.B"),
+      cls("tests.A").fun("method") -> "B$" -> cls("tests.B$"),
+    )
+
+    cases.foreach { case ((Sym(owner), query), Sym(target)) =>
+      val Some((lookedUp, _)) = MemberLookup.lookup(parseQuery(query), owner)
+      assertSame(s"$owner / $query", target, lookedUp)
+    }
+  }
+
+  def testStrictMemberLookup(): Unit = {
+    val owner = cls("tests.A").symbol
+    val query = "#A"
+
+    assertTrue("strict member lookup should not look outside", MemberLookup.lookup(parseQuery(query), owner).isEmpty)
+  }
+
+  given r.type = r
+
+  def parseQuery(query: String): Query = {
+    val Right(parsed) = QueryParser(query).tryReadQuery()
+    parsed
+  }
+
+  case class Sym(symbol: r.Symbol) {
+    def fld(name: String) =
+      def hackResolveModule(s: r.Symbol): r.Symbol =
+        if s.flags.is(r.Flags.Object) then s.moduleClass else s
+      Sym(hackResolveModule(symbol.field(name)))
+    def fun(name: String) =
+      val List(sym) = symbol.method(name)
+      Sym(sym)
+    def tpe(name: String) = Sym(symbol.typeMember(name))
+  }
+
+  def cls(fqn: String) = Sym(r.Symbol.classSymbol(fqn))
+}
+
+class MemberLookupTests {
+
+  @Test
+  def test(): Unit = {
+    import scala.tasty.inspector.TastyInspector
+    class Inspector extends TastyInspector:
+      var alreadyRan: Boolean = false
+      override def processCompilationUnit(using r: Reflection)(root: r.Tree): Unit =
+        if !alreadyRan then
+          this.test()
+          alreadyRan = true
+
+      def test()(using r: Reflection): Unit = {
+        import dotty.dokka.tasty.comments.MemberLookup
+
+        val cases = LookupTestCases[r.type](r)
+
+        cases.testAll()
+      }
+
+    Inspector().inspect("", listOurClasses())
+  }
+
+  def listOurClasses(): List[String] = {
+    import java.io.File
+    import scala.collection.mutable.ListBuffer
+
+    val classRoot = File("target/scala-0.27/classes")
+
+    def go(bld: ListBuffer[String])(file: File): Unit =
+      file.listFiles.foreach { f =>
+        if f.isFile() then
+          if f.toString.endsWith(".tasty") then
+            bld.append(f.toString
+              .stripPrefix(classRoot.toString + "/")
+              .stripSuffix(".tasty")
+              .replaceAll("/", ".")
+            )
+        else go(bld)(f)
+      }
+
+    if classRoot.isDirectory then
+      val bld = new ListBuffer[String]
+      go(bld)(classRoot)
+      bld.result
+    else
+      sys.error(s"Class root could not be found: $classRoot")
+  }
+}

--- a/src/test/scala/dotty/dokka/tasty/comments/QueryParserTests.scala
+++ b/src/test/scala/dotty/dokka/tasty/comments/QueryParserTests.scala
@@ -39,6 +39,14 @@ class QueryParserTests {
     testSuccess("#foo(ignoredOverloadDefinition*", StrictMemberId("foo"))
     testSuccess("#bar[ignoredOverloadDefinition*", StrictMemberId("bar"))
 
+    testSuccess("\\#abc", Id("#abc"))
+    testSuccess("a\\.b", Id("a.b"))
+    testSuccess("a\\#b", Id("a#b"))
+    testSuccess("ab\\ ", Id("ab "))
+
+    testSuccess("#foo\\(ignoredOverloadDefinition*", StrictMemberId("foo(ignoredOverloadDefinition*"))
+    testSuccess("#bar\\[ignoredOverloadDefinition*", StrictMemberId("bar[ignoredOverloadDefinition*"))
+
     testFailAt("#", 1)
     testFailAt("#`", 2)
     testFailAt("``", 2)
@@ -47,6 +55,9 @@ class QueryParserTests {
     testFailAt("ab..cd", 3)
     testFailAt("ab.#cd", 3)
     testFailAt("ab#.cd", 3)
+
+    testFailAt("\\`", 1)
+    testFailAt("ab\\`", 3)
   }
 
   private def parse(input: String) = QueryParser(input).tryReadQuery()

--- a/src/test/scala/dotty/dokka/tasty/comments/QueryParserTests.scala
+++ b/src/test/scala/dotty/dokka/tasty/comments/QueryParserTests.scala
@@ -1,0 +1,63 @@
+package dotty.dokka.tasty.comments
+
+import org.junit.{Test, Rule}
+import org.junit.Assert.{assertSame, assertTrue, assertEquals}
+
+class QueryParserTests {
+  @Test def test() = {
+    import Query._
+
+    def l2q(shorthand: ((String | Qual), Char)*)(last: String): QuerySegment = {
+      if shorthand.isEmpty then Query.Id(last) else {
+        val head = shorthand.head
+        val tail = shorthand.tail
+        head match {
+          case ((id: String), ch) => Query.QualifiedId(Query.Qual.Id(id), ch, l2q(tail : _*)(last))
+          case ((qual: Qual), ch) => Query.QualifiedId(qual, ch, l2q(tail : _*)(last))
+        }
+      }
+    }
+
+    extension [A <: String | Qual](self: A) def dot = (self, '.')
+    extension [A <: String | Qual](self: A) def hash = (self, '#')
+
+    testSuccess("#abc", StrictMemberId("abc"))
+    testSuccess("a.b.c#d", l2q("a".dot, "b".dot, "c".hash)("d"))
+
+    testSuccess("`a.b c#d`", Id("a.b c#d"))
+    testSuccess("#`a.b c#d`", StrictMemberId("a.b c#d"))
+
+    testSuccess("a.`b.c#d e`.g", l2q("a".dot, "b.c#d e".dot)("g"))
+    testSuccess("a.`b.c#d e`#g", l2q("a".dot, "b.c#d e".hash)("g"))
+
+    testSuccess("this.foo", l2q(Qual.This.dot)("foo"))
+    testSuccess("package.foo", l2q(Qual.Package.dot)("foo"))
+
+    testSuccess("`this`.foo", l2q("this".dot)("foo"))
+    testSuccess("`package`.foo", l2q("package".dot)("foo"))
+
+    testSuccess("#foo(ignoredOverloadDefinition*", StrictMemberId("foo"))
+    testSuccess("#bar[ignoredOverloadDefinition*", StrictMemberId("bar"))
+
+    testFailAt("#", 1)
+    testFailAt("#`", 2)
+    testFailAt("``", 2)
+    testFailAt("`abc", 4)
+
+    testFailAt("ab..cd", 3)
+    testFailAt("ab.#cd", 3)
+    testFailAt("ab#.cd", 3)
+  }
+
+  private def parse(input: String) = QueryParser(input).tryReadQuery()
+
+  private def testSuccess(input: String, expected: Query) = {
+    val Right(got) = parse(input)
+    assertEquals(expected, got)
+  }
+
+  private def testFailAt(input: String, char: Int) = {
+    val Left(err) = parse(input)
+    assertEquals(s"expected to fail at $char : $input", char, err.at)
+  }
+}


### PR DESCRIPTION
What's in the title.

Scaladoc apparently performs a DFS as well when doing member lookup, the only reason I know this is because I read the sources so I think I'm going to hold my horses on implementing that.

We also treat `this` and `package` identifiers as special, but those are quite unlikely to be used as actual identifiers. I'm planning to add support for quoting those anyway.

Fixes #129.