### PR TITLE
Use relative links for the icons font (small PR)

### DIFF
--- a/src/main/resources/dotty_res/styles/dotty-icons.css
+++ b/src/main/resources/dotty_res/styles/dotty-icons.css
@@ -1,8 +1,8 @@
 @font-face {
   font-family: 'dotty-icons';
   src:
-    url('/fonts/dotty-icons.woff?kefi7x') format('woff'),
-    url('/fonts/dotty-icons.ttf?kefi7x') format('truetype');
+    url('../fonts/dotty-icons.woff?kefi7x') format('woff'),
+    url('../fonts/dotty-icons.ttf?kefi7x') format('truetype');
   font-weight: normal;
   font-style: normal;
   font-display: block;


### PR DESCRIPTION
This fixes some icons in environments where the site root isn't `/`, like on S3.