### PR TITLE
Update Dotty version to 0.27.0-RC1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val dottyVersion = "0.26.0-RC1"
+val dottyVersion = "0.27.0-RC1"
 val dokkaVersion = "1.4.0"
 val kotlinxVersion = "0.7.2" // upgrade when upgrading dokka
 val flexmarkVersion = "0.42.12"

--- a/build.sbt
+++ b/build.sbt
@@ -54,7 +54,7 @@ compile.in(Compile) := (compile.in(Compile).dependsOn(buildDokkaApi)).value
 
 val generateSelfDocumentation = inputKey[Unit]("Generate example documentation")
 generateSelfDocumentation := {
-  run.in(Compile).fullInput(" -o output/self -t target/scala-0.26/classes -d documentation -n scala3doc -s src/main/scala=https://github.com/lampepfl/scala3doc/tree/master/src/main/scala#L").evaluated // TODO #35 proper sbt integration
+  run.in(Compile).fullInput(" -o output/self -t target/scala-0.27/classes -d documentation -n scala3doc -s src/main/scala=https://github.com/lampepfl/scala3doc/tree/master/src/main/scala#L").evaluated // TODO #35 proper sbt integration
 }
 
 unmanagedJars in Compile += dokkaJavaApiJar

--- a/src/main/scala/dotty/dokka/tasty/TypesSupport.scala
+++ b/src/main/scala/dotty/dokka/tasty/TypesSupport.scala
@@ -8,23 +8,25 @@ trait TypesSupport:
     self: TastyParser =>
     import reflect._
 
-    extension on (tpeTree: Tree):
-        def dokkaType(using cxt: reflect.Context): Bound =
-            val data = tpeTree match
-                case TypeBoundsTree(low, high) => typeBound(low.tpe, low = true) ++ typeBound(high.tpe, low = false)
-                case tpeTree: TypeTree =>  inner(tpeTree.tpe)
-                case term:  Term => inner(term.tpe)
+    given TreeSyntax as AnyRef:
+        extension (tpeTree: Tree):
+            def dokkaType(using cxt: reflect.Context): Bound =
+                val data = tpeTree match
+                    case TypeBoundsTree(low, high) => typeBound(low.tpe, low = true) ++ typeBound(high.tpe, low = false)
+                    case tpeTree: TypeTree =>  inner(tpeTree.tpe)
+                    case term:  Term => inner(term.tpe)
 
-            new TypeConstructor(tpeTree.symbol.dri, data.asJava, FunctionModifiers.NONE)
+                new TypeConstructor(tpeTree.symbol.dri, data.asJava, FunctionModifiers.NONE)
 
-    extension on (tpe: TypeOrBounds):
-        def dokkaType(using ctx: reflect.Context): Bound =
-            val data = inner(tpe)
-            val dri = data.collect{
-                case o: TypeParameter => o
-            }.headOption.map(_.getDri).getOrElse(defn.AnyClass.dri)
-            new TypeConstructor(dri, data.asJava, FunctionModifiers.NONE)
-     
+    given TypeOrBoundsSyntax as AnyRef:
+        extension (tpe: TypeOrBounds):
+            def dokkaType(using ctx: reflect.Context): Bound =
+                val data = inner(tpe)
+                val dri = data.collect{
+                    case o: TypeParameter => o
+                }.headOption.map(_.getDri).getOrElse(defn.AnyClass.dri)
+                new TypeConstructor(dri, data.asJava, FunctionModifiers.NONE)
+
     private def text(str: String): JProjection = new UnresolvedBound(str)
     
     private def texts(str: String): List[JProjection] = List(text(str))

--- a/src/main/scala/dotty/dokka/translators/ScalaContentBuilder.scala
+++ b/src/main/scala/dotty/dokka/translators/ScalaContentBuilder.scala
@@ -17,7 +17,7 @@ import org.jetbrains.dokka.model.properties.PropertyContainer
 import org.jetbrains.dokka.model.doc._
 
 
-extension on (sourceSets: Set[DokkaConfiguration$DokkaSourceSet]):
+extension (sourceSets: Set[DokkaConfiguration$DokkaSourceSet]):
     def toDisplay = sourceSets.map(DisplaySourceSet(_)).asJava
 
 

--- a/src/main/scala/dotty/dokka/utils.scala
+++ b/src/main/scala/dotty/dokka/utils.scala
@@ -17,10 +17,10 @@ import kotlin.jvm.functions.Function2
 import java.util.{List => JList, Set => JSet, Map => JMap}
 import org.jetbrains.dokka.DokkaConfiguration$DokkaSourceSet
 
-extension  on[T, V] (a: WithExtraProperties[T]):
+extension [T, V] (a: WithExtraProperties[T]):
   def get(key: ExtraProperty.Key[_ >: T, V]): V = a.getExtra().getMap().get(key).asInstanceOf[V]
 
-extension on[V] (map: JMap[DokkaConfiguration$DokkaSourceSet, V]):
+extension [V] (map: JMap[DokkaConfiguration$DokkaSourceSet, V]):
     def defaultValue: V = map.values.asScala.toSeq(0)
 
 class BaseKey[T, V] extends ExtraProperty.Key[T, V]:

--- a/src/test/scala/dotty/dokka/MultipleFileTest.scala
+++ b/src/test/scala/dotty/dokka/MultipleFileTest.scala
@@ -59,7 +59,7 @@ abstract class MultipleFileTest(val sourceFiles: List[String], val tastyFolders:
         val unexpectedFromSource = allFromSource.map(_._2).flatten.filter(extractSymbolName(_) != "NULL").map(cleanup)
         val unexpectedSignatureSymbolNames = unexpectedFromSource.map(extractSymbolName)
 
-        val allFromDocumentation = tastyFolders.flatMap(folder => signaturesFromDocumentation(s"target/scala-0.26/classes/tests/$folder"))
+        val allFromDocumentation = tastyFolders.flatMap(folder => signaturesFromDocumentation(s"target/scala-0.27/classes/tests/$folder"))
         val fromDocumentation = allFromDocumentation.filter(extractSymbolName(_) != "NULL").map(cleanup)
         
         val documentedSignatures = fromDocumentation.flatMap(matchSignature(_, expectedFromSource)).toSet


### PR DESCRIPTION
What it says in the title.

We needed to slightly change grouped extension method syntax, and add a wrapping object to distinguish between two `dokkaType` methods.