### PR TITLE
Do not get start/end of not-existing pos

### DIFF
--- a/src/main/scala/dotty/dokka/tasty/SyntheticSupport.scala
+++ b/src/main/scala/dotty/dokka/tasty/SyntheticSupport.scala
@@ -24,7 +24,6 @@ trait SyntheticsSupport:
     c.flags.is(Flags.CaseAcessor) || c.flags.is(Flags.Object)
 
   def isValidPos(pos: Position) =
-    val a = (pos.exists, pos.start, pos.end)
     pos.exists && pos.start != pos.end
 
   def constructorWithoutParamLists(c: ClassDef): Boolean =


### PR DESCRIPTION
This throws an exception when the pos doesn't exist, which now is happening when
documenting the stdlib.