### PR TITLE
Make all Scala snippets highlighted

### DIFF
--- a/src/main/resources/dotty_res/scripts/ux.js
+++ b/src/main/resources/dotty_res/scripts/ux.js
@@ -1,6 +1,9 @@
 window.addEventListener("DOMContentLoaded", () => {
-    document.getElementById("leftToggler").onclick = function() {
-        document.getElementById("leftColumn").classList.toggle("open");
+    var e = document.getElementById("leftToggler");
+    if (e) {
+        e.onclick = function() {
+            document.getElementById("leftColumn").classList.toggle("open");
+        };
     }
     hljs.registerLanguage('scala', highlightDotty);
     hljs.registerAliases(['dotty', 'scala3'], 'scala');


### PR DESCRIPTION
Element with id `leftToggler` doesn't exist on some pages, which could sometimes
throw an error before hljs syntax for Scala is loaded, which prevented it from
working properly.