### PR TITLE
Clean up how warnings are displayed

### DIFF
--- a/src/main/scala/dotty/dokka/tasty/comments/BaseConverter.scala
+++ b/src/main/scala/dotty/dokka/tasty/comments/BaseConverter.scala
@@ -10,9 +10,10 @@ trait BaseConverter {
   protected def withParsedQuery(queryStr: String)(thunk: Query => dkkd.DocTag): dkkd.DocTag = {
     QueryParser(queryStr).tryReadQuery() match {
       case Left(err) =>
+        val msg = err.getMessage
         // TODO: for better experience we should show source location here
-        println("WARN: " + err.getMessage)
-        dkkd.A(List(dkk.text(err.getMessage)).asJava, Map("href" -> "#").asJava)
+        println("WARN: " + msg)
+        dkkd.A(List(dkk.text(queryStr)).asJava, Map("href" -> "#").asJava)
       case Right(query) =>
         thunk(query)
     }

--- a/src/main/scala/dotty/dokka/tasty/comments/BaseConverter.scala
+++ b/src/main/scala/dotty/dokka/tasty/comments/BaseConverter.scala
@@ -13,7 +13,7 @@ trait BaseConverter {
         val msg = err.getMessage
         // TODO: for better experience we should show source location here
         println("WARN: " + msg)
-        dkkd.A(List(dkk.text(queryStr)).asJava, Map("href" -> "#").asJava)
+        dkkd.A(List(dkk.text(queryStr)).asJava, Map("title" -> msg, "href" -> "#").asJava)
       case Right(query) =>
         thunk(query)
     }

--- a/src/main/scala/dotty/dokka/tasty/comments/MarkdownConverter.scala
+++ b/src/main/scala/dotty/dokka/tasty/comments/MarkdownConverter.scala
@@ -181,7 +181,7 @@ class MarkdownConverter(val repr: Repr) extends BaseConverter {
           dkkd.DocumentationLink(sym.dri, resolveBody(default = targetText), kt.emptyMap)
         case None =>
           println(s"WARN: Definition lookup for following query failed: $queryStr")
-          dkkd.A(resolveBody(default = query.join), Map("href" -> "#").asJava)
+          dkkd.A(resolveBody(default = query.join), Map("title" -> s"Definition was not found: $queryStr", "href" -> "#").asJava)
       }
     }
   }

--- a/src/main/scala/dotty/dokka/tasty/comments/MarkdownConverter.scala
+++ b/src/main/scala/dotty/dokka/tasty/comments/MarkdownConverter.scala
@@ -161,17 +161,8 @@ class MarkdownConverter(val repr: Repr) extends BaseConverter {
     case _: mda.SoftLineBreak => emit(dkkd.Br.INSTANCE)
 
     case _ =>
-      println(s"!!! DEFAULTING @ ${n.getNodeName}")
-      emit(dkkd.P(
-        List(
-          dkkd.Span(
-            List(dkk.text(s"!!! DEFAULTING @ ${n.getNodeName}")).asJava,
-            kt.emptyMap,
-          ),
-          dkk.text(MarkdownParser.renderToText(n))
-        ).asJava,
-        kt.emptyMap
-      ))
+      println(s"WARN: Encountered unrecognised Markdown node `${n.getNodeName}`, please open an issue.")
+      emit(dkk.text(MarkdownParser.renderToText(n)))
   }
 
   def extractAndConvertSummary(doc: mdu.Document): Option[dkkd.DocTag] =
@@ -189,6 +180,7 @@ class MarkdownConverter(val repr: Repr) extends BaseConverter {
         case Some((sym, targetText)) =>
           dkkd.DocumentationLink(sym.dri, resolveBody(default = targetText), kt.emptyMap)
         case None =>
+          println(s"WARN: Definition lookup for following query failed: $queryStr")
           dkkd.A(resolveBody(default = query.join), Map("href" -> "#").asJava)
       }
     }

--- a/src/main/scala/dotty/dokka/transformers/ScalaCommentToContentConverter.scala
+++ b/src/main/scala/dotty/dokka/transformers/ScalaCommentToContentConverter.scala
@@ -6,25 +6,41 @@ import org.jetbrains.dokka.model.properties.PropertyContainer
 import org.jetbrains.dokka.pages._
 import collection.JavaConverters._
 import org.jetbrains.dokka.base.transformers.pages.comments.{DocTagToContentConverter, CommentsToContentConverter}
+import org.jetbrains.dokka.model.properties.{PropertyContainer, ExtraProperty, ExtraProperty$Key, MergeStrategy}
 import java.util.{Set => JSet, List => JList}
 
+object ScalaCommentToContentConverter extends DocTagToContentConverter {
+  override def buildContent(
+    docTag: DocTag,
+    dci: DCI,
+    sourceSets: JSet[? <: DokkaConfiguration$DokkaSourceSet],
+    styles: JSet[? <: Style],
+    extra: PropertyContainer[ContentNode]
+  ): JList[ContentNode] = docTag match {
+    case docTag: A =>
+      val superRes = super.buildContent(docTag, dci, sourceSets, styles, extra).get(0)
+      val res = superRes.withNewExtras(superRes.getExtra plus ExtraLinkAttributes(
+        title = docTag.getParams.asScala.get("title")
+      ))
+      List(res).asJava
+    case h: Html => List(
+      HtmlContentNode(
+        h.getChildren.asScala.collect{case c: Text => c}.head.getBody,
+        dci,
+        sourceSets.asScala.toSet.toDisplay.asScala.toSet,
+        styles.asScala.toSet
+      )
+    ).asJava
+    case other => super.buildContent(other, dci, sourceSets, styles, extra)
+  }
 
-object ScalaCommentToContentConverter extends CommentsToContentConverter:
-    val defaultConverter = DocTagToContentConverter()
-    override def buildContent(
-        docTag: DocTag,
-        dci: DCI,
-        sourceSets: JSet[? <: DokkaConfiguration$DokkaSourceSet],
-        styles: JSet[? <: Style],
-        extra: PropertyContainer[ContentNode]
-    ): JList[ContentNode] = docTag match {
-        case h: Html => List(
-            HtmlContentNode(
-                h.getChildren.asScala.collect{case c: Text => c}.head.getBody, 
-                dci, 
-                sourceSets.asScala.toSet.toDisplay.asScala.toSet, 
-                styles.asScala.toSet
-            )
-        ).asJava
-        case other => defaultConverter.buildContent(other, dci, sourceSets, styles, extra)
-    }
+  case class ExtraLinkAttributes(title: Option[String]) extends ExtraProperty[ContentNode] {
+    def getKey() = LinkAttributesKey
+  }
+
+  case object LinkAttributesKey extends ExtraProperty.Key[ContentNode, Null] {
+    def mergeStrategyFor(left: Null, right: Null) = MergeStrategy.Fail(
+      () => throw NotImplementedError(s"Property merging for $this is not implemented")
+    ).asInstanceOf[MergeStrategy[ContentNode]]
+  }
+}

--- a/src/main/scala/dotty/renderers/ScalaHtmlRenderer.scala
+++ b/src/main/scala/dotty/renderers/ScalaHtmlRenderer.scala
@@ -165,6 +165,26 @@ class ScalaHtmlRenderer(ctx: DokkaContext) extends SiteRenderer(ctx) {
         ).toString
     }
 
+    override def buildResolvedLink(
+        f: FlowContent,
+        node: ContentResolvedLink,
+        pageContext: ContentPage,
+        sourceSetRestriction: JSet[DisplaySourceSet],
+    ): Unit = {
+        import kotlinx.html.{Gen_consumer_tagsKt => dsl}
+        val c = f.getConsumer
+        val U = kotlin.Unit.INSTANCE
+        dsl.a(c, node.getAddress, /*target*/ null, /*classes*/ null, { e =>
+            import ScalaCommentToContentConverter._
+            // node.getExtra.getMap.asScala.get(LinkAttributesKey)
+            Option(node.get(LinkAttributesKey).asInstanceOf[ExtraLinkAttributes])
+                .flatMap(_.title)
+                .foreach(e.getAttributes.put("title", _))
+            buildText(f, node.getChildren, pageContext, sourceSetRestriction)
+            U
+        })
+    }
+
     override def buildCodeBlock(
         f: FlowContent,
         code: ContentCodeBlock,

--- a/src/main/scala/tests/tests.scala
+++ b/src/main/scala/tests/tests.scala
@@ -44,9 +44,13 @@ package tests
   *
   * And yet another: [[example.level2.Documentation]].
   *
-  * This is my friend: [[tests\.B\]]].
+  * This is my friend: [[tests.B]].
   *
   * And this is his companion: [[tests.B$ link to the companion]].
+  *
+  * And this is a link that failed to resolve [[absent]].
+  *
+  * And this is a link that failed to parse [[#]].
   *
   * @author Gal Anonim
   * @version 1.0.0
@@ -172,7 +176,7 @@ class Methods:
    *
    * Even though this line should be separated from previous one.
    *
-   * @throws scala.Error Throws errors.
+   * @throws java.lang.Error Throws errors.
    * @example
    * ```
    * (m : Methods).generic2(d(), e()): B


### PR DESCRIPTION
Emit nicer warning msgs on output, don't display massive `!!! Defaulting to X` when encountering a Markdown tag we haven't seen, add tooltips to links that failed to resolve.

Maybe we should also display them in a different colour? Nice shade of red?

For now based on top of #184, since both touch the same areas of code.