### PR TITLE
Extend symbols with members from implicit conversions/ extensions

### DIFF
--- a/dokkaJavaApi/src/main/kotlin/dokka.java.api.JavaPlugin.kt
+++ b/dokkaJavaApi/src/main/kotlin/dokka.java.api.JavaPlugin.kt
@@ -122,6 +122,12 @@ abstract class JavaDokkaPlugin : DokkaPlugin() {
         } override dokkaBase.docTagToContentConverter
     }
 
+    val implicitMembersExtensionTransformer by extending {
+        CoreExtensions.documentableTransformer providing { ctx ->
+            createImplicitMembersExtensionTransformer(ctx)
+        }
+    }
+
 
     abstract fun createSourceToDocumentableTranslator(cxt: DokkaContext, sourceSet: SourceSetWrapper): DModule
     abstract fun createSignatureProvider(ctcc: CommentsToContentConverter, logger: DokkaLogger): SignatureProvider
@@ -142,6 +148,7 @@ abstract class JavaDokkaPlugin : DokkaPlugin() {
     ): DocumentableTransformer
     abstract fun createHtmlRenderer(ctx: DokkaContext): Renderer
     abstract fun createCommentToContentConverter(): CommentsToContentConverter
+    abstract fun createImplicitMembersExtensionTransformer(ctx: DokkaContext): DocumentableTransformer
 }
 
 // TODO we probably does not need that

--- a/src/main/resources/dotty_res/styles/scalastyle.css
+++ b/src/main/resources/dotty_res/styles/scalastyle.css
@@ -410,6 +410,11 @@ dl.paramsdesc dd {
 	padding: 2px 0;
 }
 
+.platform-dependent-row dl.attributes > dd {
+  padding-left: 3em;
+}
+
+
 /* Footer */
 footer {
   display: flex;

--- a/src/main/scala/dotty/dokka/DottyDokkaPlugin.scala
+++ b/src/main/scala/dotty/dokka/DottyDokkaPlugin.scala
@@ -76,3 +76,4 @@ class DottyDokkaPlugin extends JavaDokkaPlugin:
     ) = ScalaSourceLinksTransformer(ctx, commentsToContentConverter, signatureProvider, logger)
   override def createHtmlRenderer(ctx: DokkaContext) = ScalaHtmlRenderer(ctx)
   override def createCommentToContentConverter() = ScalaCommentToContentConverter
+  override def createImplicitMembersExtensionTransformer(ctx: DokkaContext) = ImplicitMembersExtensionTransformer(ctx)

--- a/src/main/scala/dotty/dokka/model/extras.scala
+++ b/src/main/scala/dotty/dokka/model/extras.scala
@@ -68,10 +68,19 @@ case class ClasslikeExtension(
   kind: Kind, 
   companion: Option[DRI], 
   extensions: List[ExtensionGroup],
-  inheritedMethods: List[DFunction],
+  inherited: InheritedDefinitions,
   givens: List[Documentable]
 ) extends ExtraProperty[DClasslike]:
   override def getKey = ClasslikeExtension
+
+case class InheritedDefinitions(
+  classlikes: List[DClasslike],
+  types: List[DProperty],
+  methods: List[DFunction],
+  fields: List[DProperty],
+  extensions: List[ExtensionGroup],
+  givens: List[Documentable]
+)
 
 object ClasslikeExtension extends BaseKey[DClasslike, ClasslikeExtension]
 
@@ -105,3 +114,8 @@ object AnnotationsInfo extends BaseKey[Documentable, AnnotationsInfo]:
     case class PrimitiveParameter(val name: Option[String] = None, val value: String) extends AnnotationParameter
     case class LinkParameter(val name: Option[String] = None, val dri: DRI, val value: String) extends AnnotationParameter
     case class UnresolvedParameter(val name: Option[String] = None, val unresolvedText: String) extends AnnotationParameter
+
+case class IsInherited(flag: Boolean) extends ExtraProperty[Documentable]:
+  override def getKey = IsInherited
+
+object IsInherited extends BaseKey[Documentable, IsInherited]

--- a/src/main/scala/dotty/dokka/model/extras.scala
+++ b/src/main/scala/dotty/dokka/model/extras.scala
@@ -84,6 +84,28 @@ case class InheritedDefinitions(
 
 object ClasslikeExtension extends BaseKey[DClasslike, ClasslikeExtension]
 
+
+case class PackageExtension(
+  extensions: List[ExtensionGroup],
+  givens: List[Documentable]
+) extends ExtraProperty[DPackage]:
+  override def getKey = PackageExtension
+
+object PackageExtension extends BaseKey[DPackage, PackageExtension]:
+  def apply(ce: ClasslikeExtension): PackageExtension = PackageExtension(ce.extensions, ce.givens)
+
+case class ImplicitMembers(
+  methods: Map[DFunction, Documentable] = Map.empty,
+  inheritedMethods: Map[DFunction, Documentable] = Map.empty,
+  properties: Map[DProperty, Documentable] = Map.empty,
+  inheritedProperties: Map[DProperty, Documentable] = Map.empty,
+  inheritedExtensions: Map[DFunction, Documentable] = Map.empty
+) extends ExtraProperty[DClasslike]:
+  override def getKey = ImplicitMembers
+
+object ImplicitMembers extends BaseKey[DClasslike, ImplicitMembers]
+
+
 case class SourceLinks(
   links: Map[DokkaConfiguration$DokkaSourceSet, String]
 ) extends ExtraProperty[Documentable]:
@@ -106,6 +128,11 @@ object PropertyExtension extends BaseKey[DProperty, PropertyExtension]
 
 case class AnnotationsInfo(val annotations: List[AnnotationsInfo.Annotation]) extends ExtraProperty[Documentable]:
     override def getKey = AnnotationsInfo
+
+case class ImplicitConversions(val conversions: List[ImplicitConversion]) extends ExtraProperty[WithScope]:
+  override def getKey = ImplicitConversions
+
+object ImplicitConversions extends BaseKey[WithScope, ImplicitConversions]
 
 object AnnotationsInfo extends BaseKey[Documentable, AnnotationsInfo]:
     case class Annotation(val dri: DRI, val params: List[AnnotationParameter])

--- a/src/main/scala/dotty/dokka/model/scalaModel.scala
+++ b/src/main/scala/dotty/dokka/model/scalaModel.scala
@@ -75,3 +75,4 @@ object ScalaTagWrapper {
     descTag: DocTag
   ) extends NamedTagWrapper(descTag, name, null)
 }
+case class ImplicitConversion(conversion: Documentable, from: DRI, to: DRI)

--- a/src/main/scala/dotty/dokka/tasty/PackageSupport.scala
+++ b/src/main/scala/dotty/dokka/tasty/PackageSupport.scala
@@ -4,6 +4,7 @@ import org.jetbrains.dokka.model._
 import org.jetbrains.dokka.links._
 import org.jetbrains.dokka.model.properties._
 import org.jetbrains.dokka.model.doc.DocumentationNode
+import dotty.dokka._
 
 import collection.JavaConverters._
 
@@ -28,8 +29,8 @@ trait PackageSupport:
     }
 
     def parsePackageObject(pckObj: ClassDef): DPackage =
-        parseClasslike(pckObj) match{
-          case clazz:DClass =>
+        parseClasslike(pckObj) match {
+          case clazz: DClass =>
             DPackage(
               new DRI(pckObj.symbol.dri.getPackageName, null, null, PointingToDeclaration.INSTANCE, null),
               clazz.getFunctions,
@@ -40,6 +41,7 @@ trait PackageSupport:
               null,
               sourceSet.toSet,
               PropertyContainer.Companion.empty()
+                .plus(PackageExtension(clazz.get(ClasslikeExtension)))
             )
         }
         

--- a/src/main/scala/dotty/dokka/tasty/TastyParser.scala
+++ b/src/main/scala/dotty/dokka/tasty/TastyParser.scala
@@ -13,6 +13,7 @@ import org.jetbrains.dokka.plugability.DokkaContext
 import dokka.java.api._
 import collection.JavaConverters._
 import org.jetbrains.dokka.model.properties.PropertyContainer
+import org.jetbrains.dokka.model.properties.PropertyContainerKt._
 import org.jetbrains.dokka.model.properties.{WithExtraProperties}
 import java.util.{List => JList}
 
@@ -126,7 +127,7 @@ trait DokkaBaseTastyInspector:
             f.getDocumentation,
             null,
             sourceSet.toSet,
-            PropertyContainer.Companion.empty()
+            f.getExtra
           )
         )
         found.getOrElse(throw IllegalStateException("No package for entries found"))
@@ -136,7 +137,8 @@ trait DokkaBaseTastyInspector:
   extension (self: DPackage) def mergeWith(other: DPackage): DPackage =
     val doc1 = self.getDocumentation.asScala.get(sourceSet.getSourceSet).map(_.getChildren).getOrElse(Nil.asJava)
     val doc2 = other.getDocumentation.asScala.get(sourceSet.getSourceSet).map(_.getChildren).getOrElse(Nil.asJava)
-    DPackage(
+    mergeExtras(
+      DPackage(
         self.getDri,
         (self.getFunctions.asScala ++ other.getFunctions.asScala).asJava,
         (self.getProperties.asScala ++ other.getProperties.asScala).asJava,
@@ -152,6 +154,9 @@ trait DokkaBaseTastyInspector:
         null,
         sourceSet.toSet,
         PropertyContainer.Companion.empty()
+      ),
+      self, 
+      other
     )
 
 /** Parses a single Tasty compilation unit. */

--- a/src/main/scala/dotty/dokka/transformers/ImplicitMembersExtensionTransformer.scala
+++ b/src/main/scala/dotty/dokka/transformers/ImplicitMembersExtensionTransformer.scala
@@ -1,0 +1,131 @@
+package dotty.dokka
+
+import org.jetbrains.dokka.transformers.documentation.DocumentableTransformer
+import org.jetbrains.dokka.model._
+import collection.JavaConverters
+import collection.JavaConverters._
+import org.jetbrains.dokka.plugability.DokkaContext
+import org.jetbrains.dokka.links.DRI
+import org.jetbrains.dokka.model.properties._
+
+class ImplicitMembersExtensionTransformer(ctx: DokkaContext) extends DocumentableTransformer:
+    override def invoke(original: DModule, context: DokkaContext): DModule = propagateImplicitConversionsAndExtensionMethods(original, classlikeMap(original))
+
+
+    private def classlikeMap(m: DModule): Map[DRI, DClass] = {
+        def getEntries(d: DClass): List[(DRI, DClass)] = d.getClasslikes.asScala
+            .collect{ case d: DClass => d }.toList
+            .flatMap(getEntries(_)) :+ (d.getDri, d)
+
+        m.getPackages.asScala
+            .flatMap(_.getClasslikes.asScala)
+            .collect{ case d: DClass => d }
+            .flatMap(getEntries(_))
+            .toMap
+    }
+
+    private def propagateImplicitConversionsAndExtensionMethods[T <: Documentable](
+        d: T, 
+        classlikeMap: Map[DRI, DClass],
+        currentConversions: List[ImplicitConversion] = List.empty,
+        currentExtensions: List[(Documentable, ExtensionGroup)] = List.empty,
+    ): T = d match {
+        case m: DModule => m.copy(
+            m.getName,
+            m.getPackages.asScala.map(m => propagateImplicitConversionsAndExtensionMethods(m, classlikeMap)).asJava,
+            m.getDocumentation,
+            m.getExpectPresentInSet,
+            m.getSourceSets,
+            m.getExtra
+        ).asInstanceOf[T]
+        case p: DPackage => p.copy(
+            p.getDri,
+            p.getFunctions,
+            p.getProperties,
+            p.getClasslikes.asScala.map(c => 
+                propagateImplicitConversionsAndExtensionMethods(c, classlikeMap)
+            ).asJava,
+            p.getTypealiases,
+            p.getDocumentation,
+            p.getExpectPresentInSet,
+            p.getSourceSets,
+            p.getExtra
+        ).asInstanceOf[T]
+        case c: DClass => 
+            def modifyExtensionFunction(e: DFunction) = {
+                val oldInfo = e.get(MethodExtension)
+                if(oldInfo.extensionInfo.map(_.isGrouped).get) e
+                else e.withNewExtras(
+                    PropertyContainer.Companion.empty.addAll(
+                        (e.getExtra.getMap.asScala.map(_._2).toList.filterNot(_.isInstanceOf[MethodExtension])
+                            :+ MethodExtension(oldInfo.parametersListSizes, Some(ExtensionInformation(true)))).asJava
+                    )
+                )
+            }
+            val companion = Option(c.get(ClasslikeExtension))
+                .flatMap(_.companion)
+                .map(classlikeMap(_))
+            val companionObjectConversions = companion
+                .map(_.get(ImplicitConversions))
+                .filter(_ != null)
+                .fold(List.empty)(_.conversions)
+
+            val companionObjectExtensions = companion
+                .map(c => c -> c.get(ClasslikeExtension))
+                .filter(_(1) != null)
+                .map(
+                    (companion, ext) => companion -> ext.extensions
+                )
+                .fold(List.empty)(
+                    (companion, extensions) => extensions.map(companion -> _)
+                )
+
+
+            val implicits = (currentConversions ++ companionObjectConversions)
+                .filter(_.from == c.getDri)
+                .map(conv => conv.conversion -> classlikeMap(conv.to))
+            val extensionMethods = (currentExtensions ++ companionObjectExtensions)
+                .filter(_._2._1.getType.asInstanceOf[org.jetbrains.dokka.model.TypeConstructor].getDri == c.getDri)
+                .map(e => e._1 -> e._2.extensions)
+                .flatMap(e => e._2.map(_ -> e._1))
+                .map( (key,value) => modifyExtensionFunction(key) -> value )
+                .toMap
+            val implicitMembers = ImplicitMembers(
+                implicits.flatMap( (conv, i) => i.getFunctions.asScala.toList.map(_ -> conv)).toMap,
+                implicits.flatMap( (conv, i) => i.get(ClasslikeExtension).inherited.methods.map(_ -> conv)).toMap,
+                implicits.flatMap( (conv, i) => i.getProperties.asScala.filter(_.get(PropertyExtension).kind != "type" ).toList.map(_ -> conv)).toMap,
+                implicits.flatMap( (conv, i) => i.get(ClasslikeExtension).inherited.fields.map(_ -> conv)).toMap,
+                extensionMethods
+            )
+            c.copy(
+                c.getDri,
+                c.getName,
+                c.getConstructors,
+                c.getFunctions,
+                c.getProperties,
+                c.getClasslikes.asScala.map(cl => 
+                    propagateImplicitConversionsAndExtensionMethods(
+                        cl, 
+                        classlikeMap,
+                        currentConversions ++ c.get(ImplicitConversions).conversions,
+                        currentExtensions ++ c.get(ClasslikeExtension).extensions.map(c -> _)
+                    )
+                ).asJava,
+                c.getSources,
+                c.getVisibility,
+                c.getCompanion,
+                c.getGenerics,
+                c.getSupertypes,
+                c.getDocumentation,
+                c.getExpectPresentInSet,
+                c.getModifier,
+                c.getSourceSets,
+                c.getExtra
+            ).withNewExtras(
+                c.getExtra.plus(
+                    implicitMembers
+                )
+            ).asInstanceOf[T]
+        case other => other
+    }
+

--- a/src/main/scala/example/Inheritance.scala
+++ b/src/main/scala/example/Inheritance.scala
@@ -7,3 +7,12 @@ abstract class DocumentationInheritance[T, A <: Int, B >: String, -X, +Y] extend
 class DocumentationInheritanceMethod:
     def wierdMethod[T, A <: Int, B >: String](t: T, a: A): B = ???
     def threOtherWay[A <: Nothing, B >: Any](a: A, c: B): Unit = ???
+
+class C
+class A:
+    type I = Int
+    given Unit = ()
+    extension (u: Unit) def foo = "foo"
+    object X
+    class B extends C:
+        class D extends C

--- a/src/main/scala/tests/implicitConversions.scala
+++ b/src/main/scala/tests/implicitConversions.scala
@@ -1,0 +1,73 @@
+package tests
+
+package implicitConversions
+
+given Conversion[A, B] {
+    def apply(a: A): B = ???
+}
+
+extension (a: A) def extended_bar(): String = ???
+
+class A {
+    implicit def conversion(c: C): D = ???
+    implicit def conversion: Conversion[C,D] = ???
+    implicit val a: Conversion[C,D] = ???
+
+    extension (c: C) def extended_bar(): String = ???
+
+    class C {
+        def bar: String = ???
+    }
+
+    class D extends E() {
+        def bar2: String = ???
+
+        val string: String = ???
+
+        class Bar()
+
+        type ImplicitType >: String
+
+        extension (e: E) def extended_bar(): String = ???
+    }
+
+    class E {
+        def inherited: Int = ???
+    }
+}
+
+class B {
+    def foo: Int = ???
+
+    var b: String = ???
+}
+
+class C {
+
+}
+
+object C {
+    implicit def companionConversion(c: C): B = ???
+
+    extension (c: C) def extensionInCompanion: String = ???
+}
+
+package nested {
+    extension (opt: Opt[Int]) def sum: Int = ???
+    class Opt[A]
+
+    class Lst[A]
+    object Lst {
+        extension (lst: Lst[Int]) def sum: Int = ???
+    }
+
+    object Wrapper {
+        class Foo
+        class Bar {
+            def bar = "bar"
+        }
+        implicit def foobar(foo: Foo): Bar = Bar()
+    }
+
+    class Z
+}


### PR DESCRIPTION
closes #79 

Example:
http://scala3doc.s3.eu-central-1.amazonaws.com/pr-194/self/scala3doc/tests/implicitConversions/index.html